### PR TITLE
Feature/prop and tag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/explicit-function-return-type': 0,
     '@typescript-eslint/ban-ts-ignore': 'off',
+    "@typescript-eslint/no-non-null-assertion": "off",
     'valid-jsdoc': 'off',
   },
   overrides: [

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -8,7 +8,7 @@ import { decoratedProps, DEFAULT_PROP_DECORATOR_OPTIONS, propDefinitionKeys } fr
 import type { PropDefinition, PropCastTypes } from './decorators/prop';
 import { toKebabCase } from '@kluntje/js-utils/lib/string-helpers';
 
-export { uiElement, uiElements, uiEvent, MQBasedRendered, prop } from './decorators';
+export { uiElement, uiElements, uiEvent, MQBasedRendered, prop, tag } from './decorators';
 
 type ComponentUiEl<T = any> = {
   [key in keyof T]: any;

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -4,8 +4,11 @@ import { mergeArraysBy } from '@kluntje/js-utils/lib/array-helpers';
 import { onEvent, removeEvent, waitForEvent, find, findAll } from '@kluntje/js-utils/lib/dom-helpers';
 
 import { DecoratorUiDefinition } from './decorators';
+import { decoratedProps, DEFAULT_PROP_DECORATOR_OPTIONS, propDefinitionKeys } from './decorators/prop';
+import type { PropDefinition, PropCastTypes } from './decorators/prop';
+import { toKebabCase } from '@kluntje/js-utils/lib/string-helpers';
 
-export { uiElement, uiElements, uiEvent, MQBasedRendered } from './decorators';
+export { uiElement, uiElements, uiEvent, MQBasedRendered, prop } from './decorators';
 
 type ComponentUiEl<T = any> = {
   [key in keyof T]: any;
@@ -30,6 +33,7 @@ export type ComponentArgs = {
   events?: ComponentEvent[];
   initialStates?: ComponentStates;
   reactions?: ComponentReactions;
+  props?: Record<string, undefined | null | string | boolean | number | object | PropDefinition>;
   useShadowDOM?: boolean;
   preserveChilds?: boolean;
   asyncRendering?: boolean;
@@ -52,6 +56,13 @@ export class Component extends HTMLElement {
 
   eventIdMap: WeakMap<HTMLElement | Function, string>;
 
+  [decoratedProps]?: Record<string, PropDefinition>;
+
+  // stores prop definition passed in the constructor options or as decorators
+  props: {
+    [key: string]: PropDefinition;
+  };
+
   eventBindingMap: {
     [index: string]: EventListenerOrEventListenerObject;
   };
@@ -65,6 +76,7 @@ export class Component extends HTMLElement {
     events = [],
     initialStates = {},
     reactions = {},
+    props = {},
     useShadowDOM = false,
     preserveChilds = false,
     asyncRendering = false,
@@ -99,6 +111,7 @@ export class Component extends HTMLElement {
     this.addReactions(reactions);
 
     this.mergeEvents(events);
+    this.props = this.normalizeProps({ ...props, ...(this[decoratedProps] || null) });
   }
 
   enableDecoratedProperties() {
@@ -242,6 +255,7 @@ export class Component extends HTMLElement {
     }
     this.setupComponentProps();
     this.afterComponentRender();
+    this.checkForMissingAttributes();
     this.setState({ initialized: true });
   }
 
@@ -252,6 +266,7 @@ export class Component extends HTMLElement {
     this.enableDecoratedProperties();
     this.generateUI();
     this.generateEvents();
+    this.initializeProps();
   }
 
   /**
@@ -351,6 +366,231 @@ export class Component extends HTMLElement {
         }
       }
     });
+  }
+
+  /**
+   * add property accessor and attribute change reactions
+   *
+   * @param {Record<string, any>} initializationProps
+   * @returns {{
+   *     [key: string]: PropDefinition;
+   *   }}
+   * @memberof Component
+   */
+  protected initializeProps(): void {
+    // should be called after the constructor when props are defined in subclass as class properties
+    this.addDefaultValueAndType(this.props);
+    this.addPropAccessors(this.props);
+    this.addPropsReactions(this.props);
+  }
+
+  /**
+   * normalize props having prop definition or default values,
+   *
+   * @protected
+   * @param {Record<string, any>} initializationProps
+   * @returns {{ [key: string]: PropDefinition }}
+   * @memberof Component
+   */
+  protected normalizeProps(initializationProps: Record<string, any>): { [key: string]: PropDefinition } {
+    const props: {
+      [key: string]: PropDefinition;
+    } = {};
+
+    // convert different types of props (propDef objects, or only the default value) to type `PropDefinition`
+    Object.entries(initializationProps).forEach(([propName, value]: [string, any]) => {
+      // if prop value is an object which has only the typeDefinition keys, assume it is meant as typeDef
+      const isDefProp =
+        typeof value === 'object' &&
+        value !== null &&
+        Object.keys(value).length &&
+        Object.keys(value).every(key => propDefinitionKeys.includes(key));
+
+      const prop: PropDefinition = isDefProp ? value : { defaultValue: value };
+
+      prop.attributeName = prop.attributeName || toKebabCase(propName);
+
+      props[propName] = {
+        ...DEFAULT_PROP_DECORATOR_OPTIONS,
+        ...prop,
+      };
+    });
+
+    return props;
+  }
+
+  /**
+   * fallback to the class properties value and types if props does not have a default value or type
+   *
+   * @protected
+   * @param {{ [key: string]: PropDefinition }} props
+   * @memberof Component
+   */
+  protected addDefaultValueAndType(props: { [key: string]: PropDefinition }): void {
+    Object.entries(props).forEach(([propName, prop]: [string, any]) => {
+      //@ts-ignore - prop is part of the class or will be set after the props initialization
+      prop.defaultValue = prop.hasOwnProperty('defaultValue') ? prop.defaultValue : this[propName];
+      //@ts-ignore - assuming user won't use any non supported type, in any case switch statement has a default type in the casting for that
+      prop.type =
+        prop.type ||
+        (prop.defaultValue !== null && prop.defaultValue !== undefined ? typeof prop.defaultValue : 'string');
+    });
+  }
+
+  /**
+   * provide setter and getter for the given properties
+   * to read and write value from the associated attribute
+   *
+   * @protected
+   * @param {{ [key: string]: PropDefinition }} props
+   * @returns {void}
+   * @memberof Component
+   */
+  protected addPropAccessors(props: { [key: string]: PropDefinition }): void {
+    for (const [propName, prop] of Object.entries(props)) {
+      Object.defineProperty(this, propName, {
+        enumerable: false,
+        configurable: true,
+
+        // add property accessors
+        set(value: any) {
+          if (typeof value === 'undefined' || value === null) {
+            this.removeAttribute(prop.attributeName);
+          } else if (prop.type === 'boolean') {
+            // boolean attributes have no value. they only exist on the element: `<comp class="..."  attr />`
+            if (value) this.setAttribute(prop.attributeName, '');
+            else this.removeAttribute(prop.attributeName);
+          } else if (prop.type === 'object') {
+            this.setAttribute(prop.attributeName, JSON.stringify(value));
+          }
+          // string | number
+          else {
+            this.setAttribute(prop.attributeName, String(value));
+          }
+        },
+
+        get() {
+          const attributeValue = this.getAttribute(prop.attributeName);
+
+          return attributeValue === null && prop.defaultValue !== undefined
+            ? prop.defaultValue
+            : this.castFromAttribute(attributeValue, prop.type);
+        },
+      });
+    }
+  }
+
+  /**
+   * for props having reactions, add observer to call these reactions when the attribute is modified.
+   *
+   * @protected
+   * @param {{ [key: string]: PropDefinition }} props
+   * @returns {void}
+   * @memberof Component
+   */
+  protected addPropsReactions(props: { [key: string]: PropDefinition }): void {
+    const propsWithReactions = Object.entries(props).filter(
+      ([, prop]) => Array.isArray(prop.reactions) && prop.reactions.length,
+    );
+
+    // no reactions
+    if (propsWithReactions.length === 0) return;
+
+    const invokePropReactions = (attributeName: string) => {
+      const [propName, prop] = propsWithReactions.find(([, prop]) => prop.attributeName === attributeName)!;
+
+      prop.reactions!.forEach((cb: string | Function) => {
+        if (typeof cb === 'function') {
+          // bind context to the component instance
+          // @ts-ignore - accessor for the property have been added
+          cb.call(this, this[propName]);
+          // @ts-ignore -
+        } else if (typeof cb === 'string' && cb in this && typeof this[cb] === 'function') {
+          // @ts-ignore -
+          this[cb](this[propName]);
+        } else {
+          console.error('unknown given reaction callback: ', cb);
+        }
+      });
+    };
+
+    // Options for attributes mutation observer
+    const config: MutationObserverInit = {
+      attributes: true,
+      attributeFilter: propsWithReactions.map(([, prop]) => prop.attributeName!),
+      attributeOldValue: true,
+    };
+    // Create an observer instance and call the attributeChangedCallback on mutation
+    const observer = new MutationObserver((mutationsList: MutationRecord[]) => {
+      for (const mutation of mutationsList) {
+        const oldValue = mutation.oldValue;
+        const newValue = this.getAttribute(mutation.attributeName!);
+        // attribute was re-set with the same value. No reaction needed
+        if (newValue === oldValue) return;
+
+        invokePropReactions(mutation.attributeName!);
+      }
+    });
+    observer.observe(this, config);
+
+    // call onInit reactions
+    propsWithReactions
+      .filter(([, prop]) => prop.reactOnInit)
+      .forEach(([, prop]) => invokePropReactions(prop.attributeName!));
+  }
+
+  /**
+   * warn if the component is missing some necessary attributes
+   *
+   * @protected
+   * @memberof Component
+   */
+  protected checkForMissingAttributes(): void {
+    const missingAttrs = [];
+
+    for (const prop of Object.values(this.props)) {
+      if (prop.required && !this.hasAttribute(prop.attributeName!)) {
+        missingAttrs.push(prop.attributeName);
+      }
+    }
+
+    if (missingAttrs.length)
+      console.log(`${this.tagName.toLowerCase()} is missing required attribute(s): ${missingAttrs.join(', ')}`);
+  }
+
+  /**
+   * converts the value read from attribute to the given type.
+   *
+   * @example
+   *  castFromAttribute("12", "number") === 12;
+   * @protected
+   * @param {(string | null)} attributeValue
+   * @param {PropCastTypes} [type='string']
+   * @returns {(boolean | number | Record<string, unknown> | null | string)}
+   * @throws {TypeError} - when type is object and the value can't be JSON parsed.
+   * @memberof Component
+   */
+  protected castFromAttribute(
+    attributeValue: string | null,
+    type: PropCastTypes = 'string',
+  ): boolean | number | Record<string, unknown> | null | string {
+    switch (type) {
+      case 'boolean':
+        // "" (empty string), "false" as the attribute value are all accepted as true
+        return attributeValue !== null;
+
+      case 'number':
+        // undefined, null will be interpreted as `NaN` and not `0`.
+        return parseFloat(String(attributeValue));
+
+      case 'object':
+        return JSON.parse(String(attributeValue));
+
+      // string
+      default:
+        // will return `null` when attributeValue is null and not an empty string (`""`)
+        return attributeValue;
+    }
   }
 
   /* ====================================================

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -5,6 +5,7 @@ import { onEvent, MQDefinition, getCurrentMQ } from '@kluntje/js-utils/lib/dom-h
 import { MediaQueryService } from '@kluntje/services';
 
 export { default as prop } from './prop';
+export { default as tag } from './tag';
 export type { PropDefinition, PropCastTypes } from './prop';
 
 type DecoratorEventDefinition<T> = {

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -4,6 +4,9 @@ import { pushIfNew, hasElement } from '@kluntje/js-utils/lib/array-helpers';
 import { onEvent, MQDefinition, getCurrentMQ } from '@kluntje/js-utils/lib/dom-helpers';
 import { MediaQueryService } from '@kluntje/services';
 
+export { default as prop } from './prop';
+export type { PropDefinition, PropCastTypes } from './prop';
+
 type DecoratorEventDefinition<T> = {
   handler: keyof T;
   eventName: string;

--- a/packages/core/src/decorators/prop.ts
+++ b/packages/core/src/decorators/prop.ts
@@ -12,7 +12,7 @@ export type PropCastTypes = 'string' | 'boolean' | 'number' | 'object';
 /**
  * options that can be passed to the `@prop()` decorator
  */
-export type PropDefinition = {
+export type PropDefinition<T = any> = {
   /**
    * when reading from attribute, the value should be casted to this type before storing as property.
    * Default behavior is string
@@ -29,7 +29,7 @@ export type PropDefinition = {
   /**
    * list of components methods, method name which should be called when the attribute/property is changed
    */
-  reactions?: Array<string | Function> | null;
+  reactions?: Array<keyof T | Function> | null;
   /**
    * call the reactions when during initialization of the component the attribute is present in the markup
    */

--- a/packages/core/src/decorators/prop.ts
+++ b/packages/core/src/decorators/prop.ts
@@ -1,0 +1,114 @@
+import type { Component } from '../Component';
+
+export const decoratedProps = Symbol('decorated-props');
+
+/**
+ * types property decorator can cast from html attributes
+ *
+ * @enum {string}
+ */
+export type PropCastTypes = 'string' | 'boolean' | 'number' | 'object';
+
+/**
+ * options that can be passed to the `@prop()` decorator
+ */
+export type PropDefinition = {
+  /**
+   * when reading from attribute, the value should be casted to this type before storing as property.
+   * Default behavior is string
+   */
+  type?: PropCastTypes;
+  /**
+   * Component should warn when initializing and not finding the attribute in the markup
+   */
+  required?: boolean;
+  /**
+   * default value for the property, when the attribute is not present
+   */
+  defaultValue?: string | boolean | number | Record<string, unknown> | undefined | null;
+  /**
+   * list of components methods, method name which should be called when the attribute/property is changed
+   */
+  reactions?: Array<string | Function> | null;
+  /**
+   * call the reactions when during initialization of the component the attribute is present in the markup
+   */
+  reactOnInit?: boolean;
+  /**
+   * name of the attribute connected to the prop. default is kebab case of the prop name.
+   */
+  attributeName?: string;
+};
+
+export const propDefinitionKeys = ['type', 'required', 'defaultValue', 'reactions', 'reactOnInit', 'attributeName'];
+
+/**
+ * default options used by property decorator if not passed in the argument when using the decorator
+ */
+export const DEFAULT_PROP_DECORATOR_OPTIONS: PropDefinition = {
+  required: false,
+  reactions: null,
+  reactOnInit: false,
+};
+
+/**
+ * generates a function consumable by legacy decorator implementation with the given options for the prop decorator
+ *
+ * @param {PropDefinition} options - options used for the elements property
+ * @returns {Function}
+ */
+function getPropDecorator(options: PropDefinition): PropertyDecorator {
+  return function propertyDecoratorFunction(proto: Component, propertyName: string): void {
+    proto[decoratedProps] = proto[decoratedProps] || {};
+    proto[decoratedProps]![propertyName] = options;
+  } as PropertyDecorator;
+}
+
+/**
+ * `@prop` decorator
+ *
+ * @param {(Component | PropDefinition)} prototypeOrOption - PropDefinition when decorator is called first as a function, custom element when used directly as `@prop`
+ * @param {string} [propName] - name of the property, will be kebab-cased to use as attribute
+ * @returns {Function}
+ */
+function propDecorator(prototypeOrOption: Component | PropDefinition, propName?: string): PropertyDecorator | void {
+  // used as `@prop propName = 0`
+  if (prototypeOrOption instanceof HTMLElement) {
+    // execute the function
+    const options = {
+      ...DEFAULT_PROP_DECORATOR_OPTIONS,
+    };
+
+    return getPropDecorator(options)(prototypeOrOption, propName!);
+  }
+  // used as `@prop({type: "number", required: true, ...})`
+  const options: PropDefinition = {
+    ...DEFAULT_PROP_DECORATOR_OPTIONS,
+    ...prototypeOrOption,
+  };
+  // return the function
+  return getPropDecorator(options);
+}
+
+/**
+ * `@prop` decorator to add properties to a custom element with or without specific options and reads / reflects to DOM attributes
+ * @example
+ *  JS
+ *  class MyComp extends Component {
+ *    // implicit type of boolean with default value: 0
+ *    @prop
+ *    myProp = 0;
+ *
+ *    // with more options
+ *    @prop({ type: "object", required: true, reactions: ["someCallback"] })
+ *    myOtherProp;
+ *
+ *    someCallback(myOtherProp) {
+ *      console.log(myOtherProp);
+ *    }
+ *  }
+ *
+ *  HTML
+ *  <my-comp my-prop="42" my-other-prop=[1,2]></my-comp>
+ */
+export default propDecorator as ((options: PropDefinition) => PropertyDecorator) & PropertyDecorator;

--- a/packages/core/src/decorators/tag.ts
+++ b/packages/core/src/decorators/tag.ts
@@ -1,0 +1,20 @@
+/**
+ * decorator to define a Custom Element for the given tagName
+ *
+ * @export
+ * @param {string} tagName - name of the custom element. e.g. "py-button"
+ * @example
+ * ```js
+ *    @tag("my-button")
+ *    class MyButton extends Component{
+ *    }
+ * ```
+ * @returns {Function}
+ */
+export default function tag(tagName: string): Function {
+  return function<T extends { new (): HTMLElement }>(ComponentClass: T) {
+    customElements.define(tagName, ComponentClass);
+
+    return ComponentClass;
+  };
+}

--- a/packages/js-utils/src/string-helpers/index.ts
+++ b/packages/js-utils/src/string-helpers/index.ts
@@ -3,3 +3,5 @@ export { removeMultiBS } from './lib/removeMultiBS';
 export { getWordCount } from './lib/getWordCount';
 export { removeAllNL } from './lib/removeAllNL';
 export { getCleanString } from './lib/getCleanString';
+export { toKebabCase } from './lib/toKebabCase';
+export { toCamelCase } from './lib/toCamelCase';

--- a/packages/js-utils/src/string-helpers/lib/toCamelCase.ts
+++ b/packages/js-utils/src/string-helpers/lib/toCamelCase.ts
@@ -1,0 +1,13 @@
+/**
+ * function to convert texts to camelCase for example ti generate attribute names
+ *
+ * @param {string} str - sequence of letters, dashes and spaces to be converted to camelCase
+ *
+ * @returns {string}
+ * @example
+ * toCamelCase("some-text") === "someText";
+ * toCamelCase("some other text") === "someOtherText";
+ */
+export function toCamelCase(str: string) {
+  return str.toLowerCase().replace(/(-+|\s+)[a-z]/g, txt => txt.toUpperCase()).replace(/(-|\s)+/g, "")
+}

--- a/packages/js-utils/src/string-helpers/lib/toKebabCase.ts
+++ b/packages/js-utils/src/string-helpers/lib/toKebabCase.ts
@@ -1,0 +1,21 @@
+/**
+ * converts the provided string to a kebab case (kebab.case)
+ * @example
+ *   toKebabCase("keyValuePair") === "key-value-pair"
+ *
+ * @export
+ * @param {string} str
+ * @returns {string}
+ */
+export function toKebabCase(str: string): string {
+  // from https://gist.github.com/thevangelist/8ff91bac947018c9f3bfaad6487fa149#gistcomment-2659294
+  return (
+    str
+      // get all lowercase letters that are near to uppercase ones
+      .replace(/([a-z])([A-Z])/g, "$1-$2")
+      // replace all spaces and low dash
+      .replace(/[\s_]+/g, "-")
+      // convert to lower case
+      .toLowerCase()
+  );
+}


### PR DESCRIPTION
== Description ==
 feat(core): add props feature to base component
add new `props` node to the Core Components constructor option to generate accessors for reading
and writing info from attributes via component properties, with options for default value, type casting and reactions.
add decorator for the `prop`s to be used instead of constructor argument

 feat(core): add `tag` decorator for simpler, declarative custom element definition

 feat(js-utils): add new string helpers to convert to camelCase or kebab-case

prettier still missing typescript 3.8 type only import/export syntax

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
core, js-utils