### PR TITLE
feat: replace lodash decorator for throttle with smaller implmentation

### DIFF
--- a/packages/js-utils/src/function-helpers/index.ts
+++ b/packages/js-utils/src/function-helpers/index.ts
@@ -1,0 +1,2 @@
+export { throttle } from './lib/throttle';
+export { debounce } from './lib/debounce';

--- a/packages/js-utils/src/function-helpers/lib/debounce.ts
+++ b/packages/js-utils/src/function-helpers/lib/debounce.ts
@@ -1,0 +1,42 @@
+/**
+ * returns a debounced function which when called multiple of times each time it waits the waiting duration
+ * and if the method was not called during this time, the last call will be passed to the callback.
+ *
+ * @example
+ *   const debounced = debounce(console.log, 500);
+ *   debonced("Hi");
+ *   debonced("Hello");
+ *   debonced("Hey");
+ *   if (neverMind) debonced.cancel;
+ *   // logs only "Hey"
+ *
+ *
+ *   // or instead of decorator on class methods
+ *   Class Component {
+ *     constructor() {
+ *          window.addEventListener("resize", this.resizeHandler);
+ *     }
+ *
+ *     resizeHandler = throttle(event => {
+ *       // event handlers logic
+ *     }, 100);
+ *   }
+ *
+ * @param {Function} callback - function to be caled after the last wait period
+ * @param {number} [wait=0] - waiting period in ms before the callback is invoked if during this time the debounced method was not called
+ * @returns {Function}
+ */
+export function debounce<T extends Function>(callback: T, wait: number = 0): Function {
+  let timeoutID = -1;
+  const debouncedFunction = function debouncedFunction(this: any, ...args: any[]) {
+    clearTimeout(timeoutID);
+    timeoutID = window.setTimeout(() => {
+      callback.call(this, ...args);
+    }, wait);
+  };
+
+  debouncedFunction.cancel = function cancel() {
+    clearTimeout(timeoutID);
+  };
+  return debouncedFunction;
+}

--- a/packages/js-utils/src/function-helpers/lib/throttle.ts
+++ b/packages/js-utils/src/function-helpers/lib/throttle.ts
@@ -1,0 +1,30 @@
+/**
+ * returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.
+ * call `.cancel()` on the returned function, to cancel the callback invokation.
+ *
+ *
+ * @example
+ *   window.addEventListener("resize", throttle(updateSlider, 100));
+ *
+ * @param {Function} callback - function to be caled after the last wait period
+ * @param {number} [wait=0] - waiting period in ms before the callback is invoked if during this time the debounced method was not called
+ * @returns {Function}
+ */
+export function throttle<T extends Function>(callback: T, wait: number = 0): (args?: any) => void {
+  let timeoutID: number | undefined = undefined;
+  let lastArgs: any[] = [];
+  const throttledFunction = function throttledFunction(this: any, ...args: any[]) {
+    lastArgs = args;
+    if (timeoutID !== undefined) return;
+    timeoutID = window.setTimeout(() => {
+      timeoutID = undefined;
+      callback.call(this, ...lastArgs);
+    }, wait);
+  };
+  throttledFunction.cancel = function cancel() {
+    clearTimeout(timeoutID);
+    timeoutID = undefined;
+  };
+
+  return throttledFunction;
+}

--- a/packages/js-utils/src/function-helpers/tests/debounce.test.ts
+++ b/packages/js-utils/src/function-helpers/tests/debounce.test.ts
@@ -1,0 +1,30 @@
+import { debounce } from '../lib/debounce';
+
+jest.useFakeTimers();
+
+test('(debounce) should call the callback once when debounced method is called multiple times', () => {
+  const callback = jest.fn();
+  const debounced = debounce(callback, 100);
+  debounced('first call');
+  debounced('last call');
+
+  expect(callback).not.toBeCalled();
+  jest.runAllTimers();
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith('last call');
+});
+
+test('(debounce) should call the callback not before the given waitiing period is past', () => {
+  const callback = jest.fn();
+  const debounced = debounce(callback, 100);
+
+  debounced('first call');
+  debounced('last call');
+
+  // check before the timeout has expired
+  jest.advanceTimersByTime(50);
+  expect(callback).not.toBeCalled();
+  // check after the wait duration
+  jest.advanceTimersByTime(51);
+  expect(callback).toHaveBeenCalledWith('last call');
+});

--- a/packages/js-utils/src/function-helpers/tests/throttle.test.ts
+++ b/packages/js-utils/src/function-helpers/tests/throttle.test.ts
@@ -1,0 +1,35 @@
+import { throttle } from '../lib/throttle';
+
+jest.useFakeTimers();
+
+test('(throttle) should call the callback once when throttled method is called multiple times', () => {
+  const callback = jest.fn();
+  const throttled = throttle(callback, 100);
+  throttled('first call');
+  throttled('last call');
+
+  expect(callback).not.toBeCalled();
+  jest.runAllTimers();
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith('last call');
+});
+
+test('(throttle) should call the callback when the given waitiing period is past', () => {
+  const callback = jest.fn();
+  const throttled = throttle(callback, 100);
+
+  throttled('first call');
+  throttled('second call');
+
+  // check before the timeout has expired
+  jest.advanceTimersByTime(50);
+  expect(callback).not.toBeCalled();
+  // check after the wait duration
+  jest.advanceTimersByTime(51);
+  // call again but the first timeout should be expired and the callback called
+  throttled('last call');
+  expect(callback).toHaveBeenCalledWith('second call');
+  // next tick, callback should be called a second time
+  jest.advanceTimersByTime(101);
+  expect(callback).toHaveBeenCalledWith('last call');
+});

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -4,5 +4,6 @@ import * as domHelpers from './dom-helpers';
 import * as objectHelpers from './object-helpers';
 import * as stringHelpers from './string-helpers';
 import * as dateHelpers from './date-helpers';
+import * as functionHelpers from './function-helpers';
 
-export { apiHelpers, arrayHelpers, domHelpers, objectHelpers, stringHelpers, dateHelpers };
+export { apiHelpers, arrayHelpers, domHelpers, objectHelpers, stringHelpers, dateHelpers, functionHelpers };

--- a/packages/services/src/MediaQueryService.ts
+++ b/packages/services/src/MediaQueryService.ts
@@ -1,5 +1,4 @@
-import { Throttle } from 'lodash-decorators';
-
+import { throttle } from '@kluntje/js-utils/lib/function-helpers';
 import { onEvent, getCurrentMQ, MQDefinition } from '@kluntje/js-utils/lib/dom-helpers';
 
 export class MediaQueryService {
@@ -26,8 +25,7 @@ export class MediaQueryService {
     return MediaQueryService.instance;
   }
 
-  @Throttle(100)
-  handleMQChange() {
+  handleMQChange = throttle(() => {
     const newMQ = getCurrentMQ(MediaQueryService.mediaQuerys);
     if (newMQ === this.lastMQ) {
       return;
@@ -43,5 +41,5 @@ export class MediaQueryService {
     );
 
     this.lastMQ = newMQ;
-  }
+  }, 100);
 }


### PR DESCRIPTION
fix #16

== Description ==
Provides new `throttle` and `debounce` methods, which are used for the `MediaQueryService`. This will remove the external dependency to lodash-decorator (and lodash) which had a big impact on the lib size

== Closes issue(s) ==
#16 

== Changes ==


== Affected Packages ==
js-utils,
services