### PR TITLE
[RFC] feat(core): add support for HTMLTemplateElement as the rendering template

### DIFF
--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -215,7 +215,10 @@ export class Component extends HTMLElement {
 
     if (template instanceof HTMLTemplateElement) {
       this.getUiRoot().appendChild(template.content.cloneNode(true));
-    } else {
+    } else if (this.shadowRoot) {
+      this.shadowRoot.innerHTML = template;
+    }
+    else {
       this.insertAdjacentHTML('beforeend', template);
     }
   }

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -40,7 +40,7 @@ export type ComponentArgs = {
   reactions?: ComponentReactions;
   props?: Record<string, undefined | null | string | boolean | number | object | PropDefinition>;
   useShadowDOM?: boolean;
-  preserveChilds?: boolean;
+  preserveChildren?: boolean;
   asyncRendering?: boolean;
 };
 
@@ -53,7 +53,7 @@ export class Component extends HTMLElement {
 
   useShadowDOM: boolean;
 
-  preserveChilds: boolean;
+  preserveChildren: boolean;
 
   asyncRendering: boolean;
 
@@ -81,7 +81,7 @@ export class Component extends HTMLElement {
     reactions = {},
     props = {},
     useShadowDOM = false,
-    preserveChilds = false,
+    preserveChildren = false,
     asyncRendering = false,
   }: ComponentArgs = {}) {
     super();
@@ -95,7 +95,7 @@ export class Component extends HTMLElement {
       initialized: ['onComponentInitialized'],
     };
     this.useShadowDOM = useShadowDOM;
-    this.preserveChilds = preserveChilds;
+    this.preserveChildren = preserveChildren;
     this.asyncRendering = asyncRendering;
     this.eventIdMap = new WeakMap();
     this.eventBindingMap = {};
@@ -178,9 +178,9 @@ export class Component extends HTMLElement {
 
   /**
    * Overrideable rendering Template getter
-   * @returns {string | null} rendering template for component
+   * @returns {string | null | HTMLTemplateElement} rendering template for component
    */
-  renderingTemplate(): string | null {
+  renderingTemplate(): string | null | HTMLTemplateElement {
     return null;
   }
 
@@ -208,13 +208,15 @@ export class Component extends HTMLElement {
 
   /**
    * renders Component inner Markup
-   * @param {string} template
+   * @param {string | HTMLTemplateElement} template
    */
-  render(template: string): void {
-    if (this.preserveChilds) {
-      this.getUiRoot().innerHTML += template;
+  render(template: string | HTMLTemplateElement): void {
+    if (!this.preserveChildren) this.getUiRoot().innerHTML = '';
+
+    if (template instanceof HTMLTemplateElement) {
+      this.getUiRoot().appendChild(template.content.cloneNode(true));
     } else {
-      this.getUiRoot().innerHTML = template;
+      this.insertAdjacentHTML('beforeend', template);
     }
   }
 

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -215,8 +215,8 @@ export class Component extends HTMLElement {
 
     if (template instanceof HTMLTemplateElement) {
       this.getUiRoot().appendChild(template.content.cloneNode(true));
-    } else if (this.shadowRoot) {
-      this.shadowRoot.innerHTML = template;
+    } else if (this.useShadowDOM) {
+      this.shadowRoot!.innerHTML = template;
     }
     else {
       this.insertAdjacentHTML('beforeend', template);


### PR DESCRIPTION
- suport `renderingTemplate` to return Html Template Element and using it's api to generate markup,
- instead of replacing the whole markup, append the new markup. this prevents re-upgrading of children and/or loosing outside bound event listeners
- fix typo in "preserveChilds" (->"preserveChildren")

BREAKING CHANGE: `preserveChilds` is called `preserveChildren` now

== Description ==
kluntje doesn't provide any first class intergation for lit-html, nor its usage in combination with kluntje component is documented or any examples povided. This PR allows using `<template>` elements directly in combination with kluntje web-components.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
core