### PR TITLE
feat(js-utils): add decorators for `throttle` and `debounce` helper functions

### DIFF
--- a/jsdoc2md.json
+++ b/jsdoc2md.json
@@ -1,0 +1,16 @@
+{
+  "source": {
+    "includePattern": ".+\\.ts(doc|x)?$",
+    "excludePattern": ".+\\.(test|spec).ts"
+  },
+  "plugins": [
+    "plugins/markdown",
+    "node_modules/jsdoc-babel"
+  ],
+  "babel": {
+    "extensions": ["ts", "tsx"],
+    "ignore": ["**/*.(test|spec).ts"],
+    "babelrc": false,
+	"presets": [["@babel/preset-env", { "targets": { "node": true } }], "@babel/preset-typescript"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,53 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
+      "integrity": "sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.1.8",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.17.13",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -11,19 +58,30 @@
         "@babel/highlight": "^7.8.3"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
+      "integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.8.5",
+        "invariant": "^2.2.4",
+        "semver": "^5.5.0"
+      }
+    },
     "@babel/core": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
-      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.7.tgz",
+      "integrity": "sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
+        "@babel/generator": "^7.8.7",
         "@babel/helpers": "^7.8.4",
-        "@babel/parser": "^7.8.4",
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.4",
-        "@babel/types": "^7.8.3",
+        "@babel/parser": "^7.8.7",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -34,6 +92,63 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
+          "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.7",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
+          "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+          "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.6",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -62,6 +177,108 @@
         }
       }
     },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+      "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+      "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.7.tgz",
+      "integrity": "sha512-doAA5LAKhsFCR0LAFIf+r2RSMmC+m8f/oQ+URnUET/rWeEzC0yTRmAGyWkD4sSu3xwbS7MYQ2u+xlt1V5R56KQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.7"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
+      "integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.8.6",
+        "browserslist": "^4.9.1",
+        "invariant": "^2.2.4",
+        "levenary": "^1.1.1",
+        "semver": "^5.5.0"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.6.tgz",
+      "integrity": "sha512-klTBDdsr+VFFqaDHm5rR69OpEQtO2Qv8ECxHS1mNhJJvaHArR6a1xTf5K/eZW7eZpJbhCx3NW1Yt/sKsLXLblg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-split-export-declaration": "^7.8.3"
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.6.tgz",
+      "integrity": "sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-regex": "^7.8.3",
+        "regexpu-core": "^4.6.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+      "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/types": "^7.8.3",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+      "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
     "@babel/helper-function-name": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
@@ -82,11 +299,190 @@
         "@babel/types": "^7.8.3"
       }
     },
+    "@babel/helper-hoist-variables": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+      "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz",
+      "integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.6",
+        "@babel/types": "^7.8.6",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
+          "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
     "@babel/helper-plugin-utils": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
       "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
       "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+      "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+      "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-wrap-function": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
+          "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.7",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
+          "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.8.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+          "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.6",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.6",
+            "@babel/types": "^7.8.6",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.8.3",
@@ -94,6 +490,18 @@
       "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
       "dev": true,
       "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+      "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
         "@babel/types": "^7.8.3"
       }
     },
@@ -170,10 +578,127 @@
       "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
     },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+      "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-remap-async-to-generator": "^7.8.3",
+        "@babel/plugin-syntax-async-generators": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+      "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
+      "integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
     "@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -186,6 +711,448 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+      "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz",
+      "integrity": "sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+      "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+      "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-remap-async-to-generator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+      "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+      "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
+      "integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-define-map": "^7.8.3",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+      "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
+      "integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+      "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+      "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+      "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
+      "integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+      "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+      "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+      "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
+      "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
+      "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-simple-access": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
+      "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.8.3",
+        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
+      "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+      "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+      "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+      "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.7.tgz",
+      "integrity": "sha512-brYWaEPTRimOctz2NDA3jnBbDi7SVN2T4wYuu0aqSzxC3nozFZngGaw29CJ9ZPweB7k+iFmZuoG3IVPIcXmD2g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "^7.8.7",
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+      "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
+      "integrity": "sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+      "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+      "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+      "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+      "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-regex": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+      "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+      "integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
+      "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-typescript": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+      "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.7.tgz",
+      "integrity": "sha512-BYftCVOdAYJk5ASsznKAUl53EMhfBbr8CJ1X+AJLfGPscQkwJFiaV/Wn9DPH/7fzm2v6iRYJKYHSqyynTGw0nw==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.8.6",
+        "@babel/helper-compilation-targets": "^7.8.7",
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+        "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+        "@babel/plugin-proposal-json-strings": "^7.8.3",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3",
+        "@babel/plugin-transform-arrow-functions": "^7.8.3",
+        "@babel/plugin-transform-async-to-generator": "^7.8.3",
+        "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+        "@babel/plugin-transform-block-scoping": "^7.8.3",
+        "@babel/plugin-transform-classes": "^7.8.6",
+        "@babel/plugin-transform-computed-properties": "^7.8.3",
+        "@babel/plugin-transform-destructuring": "^7.8.3",
+        "@babel/plugin-transform-dotall-regex": "^7.8.3",
+        "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+        "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+        "@babel/plugin-transform-for-of": "^7.8.6",
+        "@babel/plugin-transform-function-name": "^7.8.3",
+        "@babel/plugin-transform-literals": "^7.8.3",
+        "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+        "@babel/plugin-transform-modules-amd": "^7.8.3",
+        "@babel/plugin-transform-modules-commonjs": "^7.8.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.8.3",
+        "@babel/plugin-transform-modules-umd": "^7.8.3",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+        "@babel/plugin-transform-new-target": "^7.8.3",
+        "@babel/plugin-transform-object-super": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.8.7",
+        "@babel/plugin-transform-property-literals": "^7.8.3",
+        "@babel/plugin-transform-regenerator": "^7.8.7",
+        "@babel/plugin-transform-reserved-words": "^7.8.3",
+        "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+        "@babel/plugin-transform-spread": "^7.8.3",
+        "@babel/plugin-transform-sticky-regex": "^7.8.3",
+        "@babel/plugin-transform-template-literals": "^7.8.3",
+        "@babel/plugin-transform-typeof-symbol": "^7.8.4",
+        "@babel/plugin-transform-unicode-regex": "^7.8.3",
+        "@babel/types": "^7.8.7",
+        "browserslist": "^4.8.5",
+        "core-js-compat": "^3.6.2",
+        "invariant": "^2.2.2",
+        "levenary": "^1.1.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+          "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.8.3.tgz",
+      "integrity": "sha512-qee5LgPGui9zQ0jR1TeU5/fP9L+ovoArklEqY12ek8P/wV5ZeM/VYSQYwICeoT6FfpJTekG9Ilay5PhwsOpMHA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-transform-typescript": "^7.8.3"
       }
     },
     "@babel/runtime": {
@@ -2697,6 +3664,13 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true,
+      "optional": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2740,6 +3714,15 @@
         "babel-preset-jest": "^25.1.0",
         "chalk": "^3.0.0",
         "slash": "^3.0.0"
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -2862,6 +3845,23 @@
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true,
+      "optional": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -2908,6 +3908,17 @@
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
+      }
+    },
+    "browserslist": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
+      "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001030",
+        "electron-to-chromium": "^1.3.363",
+        "node-releases": "^1.1.50"
       }
     },
     "bs-logger": {
@@ -3088,6 +4099,12 @@
         }
       }
     },
+    "caniuse-lite": {
+      "version": "1.0.30001033",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001033.tgz",
+      "integrity": "sha512-8Ibzxee6ibc5q88cM1usPsMpJOG5CTq0s/dKOmlekPbDGKt+UrnOOTPSjQz3kVo6yL7N4SB5xd+FGLHQmbzh6A==",
+      "dev": true
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -3127,6 +4144,744 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+          "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
+            "node-pre-gyp": "*"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.6.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.3.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.9.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.14.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4.4.2"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.13",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.8.6",
+                "minizlib": "^1.2.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.3"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
     },
     "chownr": {
       "version": "1.1.4",
@@ -3962,6 +5717,24 @@
       "dev": true,
       "optional": true
     },
+    "core-js-compat": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
+      "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.8.3",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4405,6 +6178,12 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.372.tgz",
+      "integrity": "sha512-77a4jYC52OdisHM+Tne7dgWEvQT1FoNu/jYl279pP88ZtG4ZRIPyhQwAKxj6C2rzsyC1OwsOds9JlZtNncSz6g==",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -5531,6 +7310,13 @@
         "glob": "^7.1.5"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5816,6 +7602,12 @@
       "requires": {
         "minipass": "^2.6.0"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs-then-native": {
       "version": "2.0.0",
@@ -6936,6 +8728,15 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -6973,6 +8774,16 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -7897,6 +9708,16 @@
         }
       }
     },
+    "jsdoc-babel": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-babel/-/jsdoc-babel-0.5.0.tgz",
+      "integrity": "sha512-PYfTbc3LNTeR8TpZs2M94NLDWqARq0r9gx3SvuziJfmJS7/AeMKvtj0xjzOX0R/4MOVA7/FqQQK7d6U0iEoztQ==",
+      "dev": true,
+      "requires": {
+        "jsdoc-regex": "^1.0.1",
+        "lodash": "^4.17.10"
+      }
+    },
     "jsdoc-parse": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-4.0.1.tgz",
@@ -7910,6 +9731,12 @@
         "sort-array": "^2.0.0",
         "test-value": "^3.0.0"
       }
+    },
+    "jsdoc-regex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-regex/-/jsdoc-regex-1.0.1.tgz",
+      "integrity": "sha1-hCRCjVtWOtjFx/vsB5uaiwnI3Po=",
+      "dev": true
     },
     "jsdoc-to-markdown": {
       "version": "5.0.3",
@@ -8161,6 +9988,15 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
+    },
+    "levenary": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+      "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
+      "dev": true,
+      "requires": {
+        "leven": "^3.1.0"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -8790,6 +10626,15 @@
       "integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g=",
       "dev": true
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -9171,6 +11016,13 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9287,6 +11139,23 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true,
           "optional": true
+        }
+      }
+    },
+    "node-releases": {
+      "version": "1.1.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.51.tgz",
+      "integrity": "sha512-1eQEs6HFYY1kMXQPOLzCf7HdjReErmvn85tZESMczdCNVWP3Y7URYLBAyYynuI7yef1zj4HN5q+oB2x67QU0lw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -9938,6 +11807,12 @@
         "react-is": "^16.12.0"
       }
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -10242,6 +12117,131 @@
         "once": "^1.3.0"
       }
     },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
     "realpath-native": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -10342,12 +12342,37 @@
         }
       }
     },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true,
       "optional": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.2.tgz",
+      "integrity": "sha512-V4+lGplCM/ikqi5/mkkpJ06e9Bujq1NFmNLvsCs56zg3ZbzrnUzAtizZ24TXxtRX/W2jcdScwQCnbL0CICTFkQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4",
+        "private": "^0.1.8"
+      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -10364,6 +12389,43 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
       "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
       "dev": true
+    },
+    "regexpu-core": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.1.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+      "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.3.tgz",
+      "integrity": "sha512-8uZvYbnfAtEm9Ab8NTb3hdLwL4g/LQzEYP7Xs27T96abJCCE2d6r3cPZPQEsLKy0vRSGVNG+/zVGtLr86HQduA==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -12059,6 +14121,34 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
       "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     }
   },
   "devDependencies": {
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.8.7",
+    "@babel/preset-env": "^7.8.7",
+    "@babel/preset-typescript": "^7.8.3",
     "@types/jest": "25.1.3",
     "@types/node": "13.7.7",
     "@typescript-eslint/eslint-plugin": "2.22.0",
@@ -43,13 +47,14 @@
     "eslint-plugin-prettier": "3.1.2",
     "husky": "4.2.3",
     "jest": "25.1.0",
+    "jsdoc-babel": "^0.5.0",
     "jsdoc-to-markdown": "5.0.3",
     "lerna": "3.20.2",
     "lint-staged": "10.0.8",
     "prettier": "1.19.1",
     "rimraf": "3.0.2",
     "ts-jest": "25.2.1",
-    "typescript": "3.8.3"
+    "typescript": "^3.8.3"
   },
   "dependencies": {
     "rollup": "1.32.1",

--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -2,7 +2,7 @@
 <p>
   <img alt="Version" src="https://img.shields.io/badge/version-0.1.0-blue.svg?cacheSeconds=2592000" />
   <a href="#" target="_blank">
-    <img alt="License: ISC" src="https://img.shields.io/badge/License-ISC-yellow.svg" />
+    <img alt="License: Apache 2.0" src="https://img.shields.io/badge/License-Apache_2.0-yellow.svg" />
   </a>
 </p>
 
@@ -14,152 +14,104 @@
 npm install @kuntje/js-utils
 ```
 
-## Constants
+## Functions
 
 <dl>
-<dt><a href="#fetchJSON">fetchJSON</a> ⇒ <code>Promise.&lt;T&gt;</code></dt>
-<dd><p>Calls API and returns JSON as Promise</p>
-</dd>
-<dt><a href="#hasElement">hasElement</a> ⇒ <code>boolean</code></dt>
-<dd><p>checks, if element is in given array</p>
-</dd>
-<dt><a href="#isFilledArray">isFilledArray</a> ⇒ <code>boolean</code></dt>
-<dd><p>checks, whether given Array exists and has at least one element</p>
-</dd>
-<dt><a href="#mergeArraysBy">mergeArraysBy</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
-<dd><p>merge two given arrays by the given checker function</p>
-</dd>
-<dt><a href="#pushIfNew">pushIfNew</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
-<dd><p>pushes new Element to given array, if its not already in it</p>
-</dd>
-<dt><a href="#removeItem">removeItem</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
-<dd><p>removes specific Item from array and return new array</p>
-</dd>
-<dt><a href="#addDays">addDays</a> ⇒ <code>Date</code></dt>
-<dd><p>Adds given amount of days to given date</p>
-</dd>
-<dt><a href="#addLeadingZero">addLeadingZero</a> ⇒ <code>string</code></dt>
-<dd><p>Optionally Adds leading Zero to Numbers &lt; 10</p>
-</dd>
-<dt><a href="#isEqualDate">isEqualDate</a> ⇒ <code>boolean</code></dt>
-<dd><p>Checks whether given dates are equal</p>
-</dd>
-<dt><a href="#sanitizeDateGMTOffset">sanitizeDateGMTOffset</a> ⇒ <code>string</code></dt>
+<dt><a href="#fetchJSON">fetchJSON(url, [options])</a> ⇒ <code>Promise.&lt;T&gt;</code></dt>
+<dd><p>Calls API and returns JSON as Promise</p></dd>
+<dt><a href="#hasElement">hasElement(array, element)</a> ⇒ <code>boolean</code></dt>
+<dd><p>checks, if element is in given array</p></dd>
+<dt><a href="#isFilledArray">isFilledArray(array)</a> ⇒ <code>boolean</code></dt>
+<dd><p>checks, whether given Array exists and has at least one element</p></dd>
+<dt><a href="#mergeArraysBy">mergeArraysBy(array1, array2, checker)</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
+<dd><p>merge two given arrays by the given checker function</p></dd>
+<dt><a href="#pushIfNew">pushIfNew(array, newElement)</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
+<dd><p>pushes new Element to given array, if its not already in it</p></dd>
+<dt><a href="#removeItem">removeItem(array, itemToRemove)</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
+<dd><p>removes specific Item from array and return new array</p></dd>
+<dt><a href="#addDays">addDays(date, daysToAdd, [zeroHours])</a> ⇒ <code>Date</code></dt>
+<dd><p>Adds given amount of days to given date</p></dd>
+<dt><a href="#addLeadingZero">addLeadingZero(inNumber)</a> ⇒ <code>string</code></dt>
+<dd><p>Optionally Adds leading Zero to Numbers &lt; 10</p></dd>
+<dt><a href="#isEqualDate">isEqualDate(dateA, dateB)</a> ⇒ <code>boolean</code></dt>
+<dd><p>Checks whether given dates are equal</p></dd>
+<dt><a href="#sanitizeDateGMTOffset">sanitizeDateGMTOffset(date)</a> ⇒ <code>string</code></dt>
 <dd><p>Helper to make date parsing cross browser compatible
 Some browsers (e.g. Safari) need the GMT offset part to be in format &quot;+00:00&quot;
 This helper makes sure that any present GMT offset follows that format and can safely be parsed:
 Date.parse(&quot;2020-01-01T12:13:14.000+0200&quot;) // throws error in Safari
-Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p>
-</dd>
-<dt><a href="#addClass">addClass</a></dt>
-<dd><p>adds given classes to one or multiple elements</p>
-</dd>
-<dt><a href="#find">find</a> ⇒ <code>Element</code> | <code>null</code></dt>
-<dd><p>returns the first child of a specific parent matching the given selector</p>
-</dd>
-<dt><a href="#findAll">findAll</a> ⇒ <code>Array.&lt;Element&gt;</code></dt>
-<dd><p>returns all children of a specific parent matching the given selector</p>
-</dd>
-<dt><a href="#getCurrentMQ">getCurrentMQ</a> ⇒ <code>string</code></dt>
-<dd><p>returns current mediaQuery-name. e.g. &quot;MQ2&quot;</p>
-</dd>
-<dt><a href="#getInnerText">getInnerText</a> ⇒ <code>string</code></dt>
-<dd><p>returns innerText of given Element</p>
-</dd>
-<dt><a href="#getParent">getParent</a> ⇒ <code>Element</code> | <code>null</code></dt>
-<dd><p>returns parent of specific class, if found</p>
-</dd>
-<dt><a href="#getUniqueID">getUniqueID</a> ⇒ <code>string</code></dt>
-<dd><p>returns a random String to be used as ID</p>
-</dd>
-<dt><a href="#hasChild">hasChild</a> ⇒ <code>boolean</code></dt>
-<dd><p>returns if a specific parent has a child matching the given selector</p>
-</dd>
-<dt><a href="#hasClass">hasClass</a> ⇒ <code>boolean</code></dt>
-<dd><p>returns if a specific element has given class</p>
-</dd>
-<dt><a href="#inViewport">inViewport</a> ⇒ <code>boolean</code></dt>
-<dd><p>checks, whether an element is in the viewport</p>
-</dd>
-<dt><a href="#isNodeList">isNodeList</a> ⇒ <code>boolean</code></dt>
-<dd><p>checks, if target is NodeList</p>
-</dd>
-<dt><a href="#onEvent">onEvent</a></dt>
-<dd><p>adds event with given parameters</p>
-</dd>
-<dt><a href="#removeChildren">removeChildren</a></dt>
-<dd><p>removes all children of a specific parent matching the given selector</p>
-</dd>
-<dt><a href="#removeClass">removeClass</a></dt>
-<dd><p>removes given class from element</p>
-</dd>
-<dt><a href="#removeEvent">removeEvent</a></dt>
-<dd><p>removes event with given parameters</p>
-</dd>
-<dt><a href="#toggleClass">toggleClass</a></dt>
-<dd><p>toggles given class on given element</p>
-</dd>
-<dt><a href="#waitFor">waitFor</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
-<dd><p>resolves Promise after given timeout</p>
-</dd>
-<dt><a href="#waitForEvent">waitForEvent</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
-<dd><p>waits for given event for a (optional) max-timeout</p>
-</dd>
-<dt><del><a href="#getValue">getValue</a> ⇒ <code>*</code></del></dt>
-<dd><p>returns nested value without throwing an error if the parent doesn&#39;t exist</p>
-</dd>
-<dt><a href="#isEqual">isEqual</a> ⇒ <code>boolean</code></dt>
-<dd><p>compare two arguments, for object their toString values are compared</p>
-</dd>
-<dt><a href="#toArray">toArray</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
-<dd><p>returns the argument wrapped in an array if it isn&#39;t array itself</p>
-</dd>
-<dt><a href="#toString">toString</a> ⇒ <code>string</code></dt>
-<dd><p>returns stringified value for the given argument</p>
-</dd>
-<dt><a href="#getCleanString">getCleanString</a> ⇒ <code>string</code></dt>
-<dd><p>removes all multi Whitespaces and Newlines in given string</p>
-</dd>
-<dt><a href="#getWordCount">getWordCount</a> ⇒ <code>number</code></dt>
-<dd><p>returns number of words in a given text</p>
-</dd>
-<dt><a href="#removeAllBS">removeAllBS</a> ⇒ <code>string</code></dt>
-<dd><p>removes all Whitespaces in given string</p>
-</dd>
-<dt><a href="#removeAllNL">removeAllNL</a> ⇒ <code>string</code></dt>
-<dd><p>removes all Newlines in given string</p>
-</dd>
-<dt><a href="#removeMultiBS">removeMultiBS</a> ⇒ <code>string</code></dt>
-<dd><p>removes multi Whitespaces in given string</p>
-</dd>
-</dl>
-
-## Functions
-
-<dl>
+Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p></dd>
+<dt><a href="#addClass">addClass(elements, ...classNames)</a></dt>
+<dd><p>adds given classes to one or multiple elements</p></dd>
+<dt><a href="#find">find(parent, selector)</a> ⇒ <code>Element</code> | <code>null</code></dt>
+<dd><p>returns the first child of a specific parent matching the given selector</p></dd>
+<dt><a href="#findAll">findAll(parent, selector)</a> ⇒ <code>Array.&lt;Element&gt;</code></dt>
+<dd><p>returns all children of a specific parent matching the given selector</p></dd>
 <dt><a href="#callback">callback(node, index)</a> ⇒</dt>
 <dd></dd>
+<dt><a href="#getCurrentMQ">getCurrentMQ(mediaQueries)</a> ⇒ <code>string</code></dt>
+<dd><p>returns current mediaQuery-name. e.g. &quot;MQ2&quot;</p></dd>
+<dt><a href="#getInnerText">getInnerText(el)</a> ⇒ <code>string</code></dt>
+<dd><p>returns innerText of given Element</p></dd>
+<dt><a href="#getParent">getParent(element, parentSelector)</a> ⇒ <code>Element</code> | <code>null</code></dt>
+<dd><p>returns parent of specific class, if found</p></dd>
+<dt><a href="#getUniqueID">getUniqueID()</a> ⇒ <code>string</code></dt>
+<dd><p>returns a random String to be used as ID</p></dd>
+<dt><a href="#hasChild">hasChild(parent, childSelector)</a> ⇒ <code>boolean</code></dt>
+<dd><p>returns if a specific parent has a child matching the given selector</p></dd>
+<dt><a href="#hasClass">hasClass(element, className)</a> ⇒ <code>boolean</code></dt>
+<dd><p>returns if a specific element has given class</p></dd>
+<dt><a href="#inViewport">inViewport(element, [parent])</a> ⇒ <code>boolean</code></dt>
+<dd><p>checks, whether an element is in the viewport</p></dd>
+<dt><a href="#isNodeList">isNodeList(target)</a> ⇒ <code>boolean</code></dt>
+<dd><p>checks, if target is NodeList</p></dd>
+<dt><a href="#onEvent">onEvent(target, events, handler, context)</a></dt>
+<dd><p>adds event with given parameters</p></dd>
+<dt><a href="#removeChildren">removeChildren(parent, selector)</a></dt>
+<dd><p>removes all children of a specific parent matching the given selector</p></dd>
+<dt><a href="#removeClass">removeClass(elements, ...classNames)</a></dt>
+<dd><p>removes given class from element</p></dd>
+<dt><a href="#removeEvent">removeEvent(target, events, handler, context)</a></dt>
+<dd><p>removes event with given parameters</p></dd>
+<dt><a href="#toggleClass">toggleClass(elements, className, add)</a></dt>
+<dd><p>toggles given class on given element</p></dd>
+<dt><a href="#waitFor">waitFor(timeout)</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
+<dd><p>resolves Promise after given timeout</p></dd>
+<dt><a href="#waitForEvent">waitForEvent(target, eventName, timeout)</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
+<dd><p>waits for given event for a (optional) max-timeout</p></dd>
 <dt><a href="#debounce">debounce(callback, [wait])</a> ⇒ <code>function</code></dt>
 <dd><p>returns a debounced function which when called multiple of times each time it waits the waiting duration
-and if the method was not called during this time, the last call will be passed to the callback.</p>
-</dd>
+and if the method was not called during this time, the last call will be passed to the callback.</p></dd>
 <dt><a href="#decoratorGenerator">decoratorGenerator(func)</a> ⇒ <code>function</code></dt>
 <dd><p>generates a decorator factory for the provided helper function.
-helper function should have this signature: <code>(Function, ...args: any[]) =&gt; Function</code></p>
-</dd>
+helper function should have this signature: <code>(Function, ...args: any[]) =&gt; Function</code></p></dd>
 <dt><a href="#throttle">throttle(callback, [wait])</a> ⇒ <code>function</code></dt>
 <dd><p>returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.
-call <code>.cancel()</code> on the returned function, to cancel the callback invocation.</p>
-</dd>
+call <code>.cancel()</code> on the returned function, to cancel the callback invocation.</p></dd>
+<dt><del><a href="#getValue">getValue(obj, path)</a> ⇒ <code>*</code></del></dt>
+<dd><p>returns nested value without throwing an error if the parent doesn't exist</p></dd>
+<dt><a href="#isEqual">isEqual(arg1, arg2)</a> ⇒ <code>boolean</code></dt>
+<dd><p>compare two arguments, for object their toString values are compared</p></dd>
 <dt><a href="#naiveClone">naiveClone(arg)</a> ⇒ <code>Nullable.&lt;T&gt;</code> | <code>Array.&lt;T&gt;</code></dt>
-<dd><p>returns a deep link of the provided argument</p>
-</dd>
+<dd><p>returns a deep link of the provided argument</p></dd>
+<dt><a href="#toArray">toArray(arg)</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
+<dd><p>returns the argument wrapped in an array if it isn't array itself</p></dd>
+<dt><a href="#toString">toString(arg)</a> ⇒ <code>string</code></dt>
+<dd><p>returns stringified value for the given argument</p></dd>
+<dt><a href="#getCleanString">getCleanString(inputString)</a> ⇒ <code>string</code></dt>
+<dd><p>removes all multi Whitespaces and Newlines in given string</p></dd>
+<dt><a href="#getWordCount">getWordCount(text)</a> ⇒ <code>number</code></dt>
+<dd><p>returns number of words in a given text</p></dd>
+<dt><a href="#removeAllBS">removeAllBS(inputString)</a> ⇒ <code>string</code></dt>
+<dd><p>removes all Whitespaces in given string</p></dd>
+<dt><a href="#removeAllNL">removeAllNL(inputString)</a> ⇒ <code>string</code></dt>
+<dd><p>removes all Newlines in given string</p></dd>
+<dt><a href="#removeMultiBS">removeMultiBS(inputString)</a> ⇒ <code>string</code></dt>
+<dd><p>removes multi Whitespaces in given string</p></dd>
 <dt><a href="#toCamelCase">toCamelCase(str)</a> ⇒ <code>string</code></dt>
-<dd><p>function to convert texts to camelCase for example ti generate attribute names</p>
-</dd>
+<dd><p>function to convert texts to camelCase for example ti generate attribute names</p></dd>
 <dt><a href="#toKebabCase">toKebabCase(str)</a> ⇒ <code>string</code></dt>
-<dd><p>converts the provided string to a kebab case (kebab-case)</p>
-</dd>
+<dd><p>converts the provided string to a kebab case (kebab-case)</p></dd>
 </dl>
 
 ## Typedefs
@@ -167,16 +119,15 @@ call <code>.cancel()</code> on the returned function, to cancel the callback inv
 <dl>
 <dt><a href="#callback">callback</a> : <code>function</code></dt>
 <dd><p>iterates over all nodes in a node list
-(necessary because IE11 doesn&#39;t support .forEach  * for NodeLists)</p>
-</dd>
+(necessary because IE11 doesn't support .forEach  * for NodeLists)</p></dd>
 </dl>
 
 <a name="fetchJSON"></a>
 
-## fetchJSON ⇒ <code>Promise.&lt;T&gt;</code>
-Calls API and returns JSON as Promise
+## fetchJSON(url, [options]) ⇒ <code>Promise.&lt;T&gt;</code>
+<p>Calls API and returns JSON as Promise</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -185,18 +136,20 @@ Calls API and returns JSON as Promise
 
 **Example**  
 ```js
-// use with async/awaitconst myApiResponse = await fetchJSON("https://some.api/path")
+// use with async/await
+const myApiResponse = await fetchJSON("https://some.api/path")
 ```
 **Example**  
 ```js
-// use as normal promisefetchJSON("https://some.api/path").then((data) => console.log("myData:", data));
+// use as normal promise
+fetchJSON("https://some.api/path").then((data) => console.log("myData:", data));
 ```
 <a name="hasElement"></a>
 
-## hasElement ⇒ <code>boolean</code>
-checks, if element is in given array
+## hasElement(array, element) ⇒ <code>boolean</code>
+<p>checks, if element is in given array</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -205,14 +158,18 @@ checks, if element is in given array
 
 **Example**  
 ```js
-const fruits = ["Banana", "Orange", "Apple", "Mango"];if (hasElement(fruits, "Apple")) {  console.log("You got an Apple");}
+const fruits = ["Banana", "Orange", "Apple", "Mango"];
+
+if (hasElement(fruits, "Apple")) {
+  console.log("You got an Apple");
+}
 ```
 <a name="isFilledArray"></a>
 
-## isFilledArray ⇒ <code>boolean</code>
-checks, whether given Array exists and has at least one element
+## isFilledArray(array) ⇒ <code>boolean</code>
+<p>checks, whether given Array exists and has at least one element</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -220,31 +177,84 @@ checks, whether given Array exists and has at least one element
 
 **Example**  
 ```js
-const myBooks = await fetchJSON("https://my-book-store.api/books");if (isFilledArray(myBooks)) {  console.log(`${myBooks.length} Books found!`)} else {  console.log("Sorry, no Books found");}
+const myBooks = await fetchJSON("https://my-book-store.api/books");
+if (isFilledArray(myBooks)) {
+  console.log(`${myBooks.length} Books found!`)
+} else {
+  console.log("Sorry, no Books found");
+}
 ```
 <a name="mergeArraysBy"></a>
 
-## mergeArraysBy ⇒ <code>Array.&lt;T&gt;</code>
-merge two given arrays by the given checker function
+## mergeArraysBy(array1, array2, checker) ⇒ <code>Array.&lt;T&gt;</code>
+<p>merge two given arrays by the given checker function</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | array1 | <code>Array.&lt;T&gt;</code> |  |
 | array2 | <code>Array.&lt;T&gt;</code> |  |
-| checker | <code>function</code> | if this function returns true for a specific element combination the elements are getting merged |
+| checker | <code>function</code> | <p>if this function returns true for a specific element combination the elements are getting merged</p> |
 
 **Example**  
 ```js
-const defaultUsers = [  {    name: "Admin",    mail: "admin@company.com"  },  {    name: "CI",    mail: "ci@company.com"  }];const projectUsers = [  {    name: "Admin",    mail: "admin@company.com"  },  {    name: "User1",    mail: "user-one@company.com"  },  {    name: "User2",    mail: "user-two@company.com"  }];const userList = mergeArraysBy(defaultUsers, projectUsers, (defaultUser, array) => {  return !array.some((projectUser) => projectUser.mail === defaultUser.mail)})// userList// [//   {//     "name": "CI",//     "mail": "ci@company.com"//   },//   {//     "name": "Admin",//     "mail": "admin@company.com"//   },//   {//     "name": "User1",//     "mail": "user-one@company.com"//   },//   {//     "name": "User2",//     "mail": "user-two@company.com"//   }// ]
+const defaultUsers = [
+  {
+    name: "Admin",
+    mail: "admin@company.com"
+  },
+  {
+    name: "CI",
+    mail: "ci@company.com"
+  }
+];
+
+const projectUsers = [
+  {
+    name: "Admin",
+    mail: "admin@company.com"
+  },
+  {
+    name: "User1",
+    mail: "user-one@company.com"
+  },
+  {
+    name: "User2",
+    mail: "user-two@company.com"
+  }
+];
+
+const userList = mergeArraysBy(defaultUsers, projectUsers, (defaultUser, array) => {
+  return !array.some((projectUser) => projectUser.mail === defaultUser.mail)
+})
+
+// userList
+// [
+//   {
+//     "name": "CI",
+//     "mail": "ci@company.com"
+//   },
+//   {
+//     "name": "Admin",
+//     "mail": "admin@company.com"
+//   },
+//   {
+//     "name": "User1",
+//     "mail": "user-one@company.com"
+//   },
+//   {
+//     "name": "User2",
+//     "mail": "user-two@company.com"
+//   }
+// ] 
 ```
 <a name="pushIfNew"></a>
 
-## pushIfNew ⇒ <code>Array.&lt;T&gt;</code>
-pushes new Element to given array, if its not already in it
+## pushIfNew(array, newElement) ⇒ <code>Array.&lt;T&gt;</code>
+<p>pushes new Element to given array, if its not already in it</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -253,14 +263,16 @@ pushes new Element to given array, if its not already in it
 
 **Example**  
 ```js
-const fruitStore = ["Banana", "Orange", "Apple", "Mango"];const newFruit = getInputValue(...)const newFruitStore = pushIfNew(fruitStore, newFruit);
+const fruitStore = ["Banana", "Orange", "Apple", "Mango"];
+const newFruit = getInputValue(...)
+const newFruitStore = pushIfNew(fruitStore, newFruit);
 ```
 <a name="removeItem"></a>
 
-## removeItem ⇒ <code>Array.&lt;T&gt;</code>
-removes specific Item from array and return new array
+## removeItem(array, itemToRemove) ⇒ <code>Array.&lt;T&gt;</code>
+<p>removes specific Item from array and return new array</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -269,31 +281,33 @@ removes specific Item from array and return new array
 
 **Example**  
 ```js
-const fruitStore = ["Banana", "Orange", "Apple", "Mango"];const newFruitStore = removeItem(fruitStore, "Apple"); // ["Banana", "Orange", "Mango"]
+const fruitStore = ["Banana", "Orange", "Apple", "Mango"];
+const newFruitStore = removeItem(fruitStore, "Apple"); // ["Banana", "Orange", "Mango"]
 ```
 <a name="addDays"></a>
 
-## addDays ⇒ <code>Date</code>
-Adds given amount of days to given date
+## addDays(date, daysToAdd, [zeroHours]) ⇒ <code>Date</code>
+<p>Adds given amount of days to given date</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| date | <code>Date</code> |  |
-| daysToAdd | <code>number</code> |  |
-| [zeroHours] | <code>boolean</code> | set time to 0:00:00 |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| date | <code>Date</code> |  |  |
+| daysToAdd | <code>number</code> |  |  |
+| [zeroHours] | <code>boolean</code> | <code>false</code> | <p>set time to 0:00:00</p> |
 
 **Example**  
 ```js
-const today = new Date();const tomorrow = addDays(today, 2);
+const today = new Date();
+const tomorrow = addDays(today, 2);
 ```
 <a name="addLeadingZero"></a>
 
-## addLeadingZero ⇒ <code>string</code>
-Optionally Adds leading Zero to Numbers < 10
+## addLeadingZero(inNumber) ⇒ <code>string</code>
+<p>Optionally Adds leading Zero to Numbers &lt; 10</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -301,14 +315,15 @@ Optionally Adds leading Zero to Numbers < 10
 
 **Example**  
 ```js
-const today = new Date();const formattedDateSting = `${addLeadingZero(today.getDate())}.${addLeadingZero(today.getMonth() + 1)}.${today.getFullYear()}`;
+const today = new Date();
+const formattedDateSting = `${addLeadingZero(today.getDate())}.${addLeadingZero(today.getMonth() + 1)}.${today.getFullYear()}`;
 ```
 <a name="isEqualDate"></a>
 
-## isEqualDate ⇒ <code>boolean</code>
-Checks whether given dates are equal
+## isEqualDate(dateA, dateB) ⇒ <code>boolean</code>
+<p>Checks whether given dates are equal</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -317,19 +332,25 @@ Checks whether given dates are equal
 
 **Example**  
 ```js
-const dateA = new Date(2020, 1, 29, 22, 30);const dateB = new Date(2020, 1, 29, 18, 20);isEqualDate(dateA. dateB); // true
+const dateA = new Date(2020, 1, 29, 22, 30);
+const dateB = new Date(2020, 1, 29, 18, 20);
+isEqualDate(dateA. dateB); // true
 ```
 <a name="sanitizeDateGMTOffset"></a>
 
-## sanitizeDateGMTOffset ⇒ <code>string</code>
-Helper to make date parsing cross browser compatibleSome browsers (e.g. Safari) need the GMT offset part to be in format "+00:00"This helper makes sure that any present GMT offset follows that format and can safely be parsed:Date.parse("2020-01-01T12:13:14.000+0200") // throws error in SafariDate.parse("2020-01-01T12:13:14.000+02:00") // succes
+## sanitizeDateGMTOffset(date) ⇒ <code>string</code>
+<p>Helper to make date parsing cross browser compatible
+Some browsers (e.g. Safari) need the GMT offset part to be in format &quot;+00:00&quot;
+This helper makes sure that any present GMT offset follows that format and can safely be parsed:
+Date.parse(&quot;2020-01-01T12:13:14.000+0200&quot;) // throws error in Safari
+Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p>
 
-**Kind**: global constant  
-**Returns**: <code>string</code> - correctly formatted date  
+**Kind**: global function  
+**Returns**: <code>string</code> - <p>correctly formatted date</p>  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| date | <code>string</code> | date string to be sanitized for parsing |
+| date | <code>string</code> | <p>date string to be sanitized for parsing</p> |
 
 **Example**  
 ```js
@@ -337,10 +358,10 @@ sanitizeDateGMTOffset("2020-01-01T12:13:14.000+0200") // "2020-01-01T12:13:14.00
 ```
 <a name="addClass"></a>
 
-## addClass
-adds given classes to one or multiple elements
+## addClass(elements, ...classNames)
+<p>adds given classes to one or multiple elements</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -349,18 +370,20 @@ adds given classes to one or multiple elements
 
 **Example**  
 ```js
-const button = document.querySelector('.button');addClass(button, 'my-button');
+const button = document.querySelector('.button');
+addClass(button, 'my-button');
 ```
 **Example**  
 ```js
-const inputs = document.querySelectorAll('input');addClass(inputs, 'my-button');
+const inputs = document.querySelectorAll('input');
+addClass(inputs, 'my-button');
 ```
 <a name="find"></a>
 
-## find ⇒ <code>Element</code> \| <code>null</code>
-returns the first child of a specific parent matching the given selector
+## find(parent, selector) ⇒ <code>Element</code> \| <code>null</code>
+<p>returns the first child of a specific parent matching the given selector</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -373,10 +396,10 @@ const input = find(document, 'input');
 ```
 <a name="findAll"></a>
 
-## findAll ⇒ <code>Array.&lt;Element&gt;</code>
-returns all children of a specific parent matching the given selector
+## findAll(parent, selector) ⇒ <code>Array.&lt;Element&gt;</code>
+<p>returns all children of a specific parent matching the given selector</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -387,13 +410,26 @@ returns all children of a specific parent matching the given selector
 ```js
 const inputs = findAll(document, 'input');
 ```
+<a name="callback"></a>
+
+## callback(node, index) ⇒
+**Kind**: global function  
+**Returns**: <p>any</p>  
+
+| Param | Type |
+| --- | --- |
+| node | <code>Node</code> | 
+| index | <code>Number</code> | 
+
 <a name="getCurrentMQ"></a>
 
-## getCurrentMQ ⇒ <code>string</code>
-returns current mediaQuery-name. e.g. "MQ2"
+## getCurrentMQ(mediaQueries) ⇒ <code>string</code>
+<p>returns current mediaQuery-name. e.g. &quot;MQ2&quot;</p>
 
-**Kind**: global constant  
-**Returns**: <code>string</code> - - mediaQuery name e.g. MQ1  
+**Kind**: global function  
+**Returns**: <code>string</code> - <ul>
+<li>mediaQuery name e.g. MQ1</li>
+</ul>  
 
 | Param | Type |
 | --- | --- |
@@ -401,14 +437,25 @@ returns current mediaQuery-name. e.g. "MQ2"
 
 **Example**  
 ```js
-const myMqs = [  {    name: 'MQ2',    query: '(min-width: 769px)'  },  {    name: 'MQ1',    query: '(min-width: 0px)'  }];const curMQ = getCurrentMQ(myMqs);
+const myMqs = [
+  {
+    name: 'MQ2',
+    query: '(min-width: 769px)'
+  },
+  {
+    name: 'MQ1',
+    query: '(min-width: 0px)'
+  }
+];
+
+const curMQ = getCurrentMQ(myMqs);
 ```
 <a name="getInnerText"></a>
 
-## getInnerText ⇒ <code>string</code>
-returns innerText of given Element
+## getInnerText(el) ⇒ <code>string</code>
+<p>returns innerText of given Element</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -416,14 +463,15 @@ returns innerText of given Element
 
 **Example**  
 ```js
-const myArticle = document.querySelector('article');const articleText = getInnerText(myArticle);
+const myArticle = document.querySelector('article');
+const articleText = getInnerText(myArticle);
 ```
 <a name="getParent"></a>
 
-## getParent ⇒ <code>Element</code> \| <code>null</code>
-returns parent of specific class, if found
+## getParent(element, parentSelector) ⇒ <code>Element</code> \| <code>null</code>
+<p>returns parent of specific class, if found</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -432,20 +480,21 @@ returns parent of specific class, if found
 
 **Example**  
 ```js
-const myText = document.querySelector('p');const myArticle = getParent(myText, 'article');
+const myText = document.querySelector('p');
+const myArticle = getParent(myText, 'article');
 ```
 <a name="getUniqueID"></a>
 
-## getUniqueID ⇒ <code>string</code>
-returns a random String to be used as ID
+## getUniqueID() ⇒ <code>string</code>
+<p>returns a random String to be used as ID</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 <a name="hasChild"></a>
 
-## hasChild ⇒ <code>boolean</code>
-returns if a specific parent has a child matching the given selector
+## hasChild(parent, childSelector) ⇒ <code>boolean</code>
+<p>returns if a specific parent has a child matching the given selector</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -454,14 +503,15 @@ returns if a specific parent has a child matching the given selector
 
 **Example**  
 ```js
-const article = document.querySelector('article');if (hasChild(article, '.cta')) console.log('please click');
+const article = document.querySelector('article');
+if (hasChild(article, '.cta')) console.log('please click');
 ```
 <a name="hasClass"></a>
 
-## hasClass ⇒ <code>boolean</code>
-returns if a specific element has given class
+## hasClass(element, className) ⇒ <code>boolean</code>
+<p>returns if a specific element has given class</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -470,14 +520,15 @@ returns if a specific element has given class
 
 **Example**  
 ```js
-const cta = document.querySelector('button');if (hasClass(cta, 'primary')) console.log("primary")
+const cta = document.querySelector('button');
+if (hasClass(cta, 'primary')) console.log("primary")
 ```
 <a name="inViewport"></a>
 
-## inViewport ⇒ <code>boolean</code>
-checks, whether an element is in the viewport
+## inViewport(element, [parent]) ⇒ <code>boolean</code>
+<p>checks, whether an element is in the viewport</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -486,14 +537,15 @@ checks, whether an element is in the viewport
 
 **Example**  
 ```js
-const image = document.querySelector('image');if (inViewport(image)) image.setAttribute('src', image.dataset('src'));
+const image = document.querySelector('image');
+if (inViewport(image)) image.setAttribute('src', image.dataset('src'));
 ```
 <a name="isNodeList"></a>
 
-## isNodeList ⇒ <code>boolean</code>
-checks, if target is NodeList
+## isNodeList(target) ⇒ <code>boolean</code>
+<p>checks, if target is NodeList</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -501,10 +553,10 @@ checks, if target is NodeList
 
 <a name="onEvent"></a>
 
-## onEvent
-adds event with given parameters
+## onEvent(target, events, handler, context)
+<p>adds event with given parameters</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -515,14 +567,15 @@ adds event with given parameters
 
 **Example**  
 ```js
-const buttons = findAll(document, 'button);onEvent(buttons, 'click', () => console.log('button clicked'), this);
+const buttons = findAll(document, 'button);
+onEvent(buttons, 'click', () => console.log('button clicked'), this);
 ```
 <a name="removeChildren"></a>
 
-## removeChildren
-removes all children of a specific parent matching the given selector
+## removeChildren(parent, selector)
+<p>removes all children of a specific parent matching the given selector</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -531,14 +584,15 @@ removes all children of a specific parent matching the given selector
 
 **Example**  
 ```js
-const article = find('article);removeChildren(article, '.ad');
+const article = find('article);
+removeChildren(article, '.ad');
 ```
 <a name="removeClass"></a>
 
-## removeClass
-removes given class from element
+## removeClass(elements, ...classNames)
+<p>removes given class from element</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -547,18 +601,20 @@ removes given class from element
 
 **Example**  
 ```js
-const button = document.querySelector('.button');removeClass(button, 'active');
+const button = document.querySelector('.button');
+removeClass(button, 'active');
 ```
 **Example**  
 ```js
-const inputs = document.querySelectorAll('input');removeClass(inputs, 'active');
+const inputs = document.querySelectorAll('input');
+removeClass(inputs, 'active');
 ```
 <a name="removeEvent"></a>
 
-## removeEvent
-removes event with given parameters
+## removeEvent(target, events, handler, context)
+<p>removes event with given parameters</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -569,14 +625,15 @@ removes event with given parameters
 
 **Example**  
 ```js
-const buttons = findAll(document, 'button);removeEvent(buttons, 'click', () => console.log('button clicked'), this);
+const buttons = findAll(document, 'button);
+removeEvent(buttons, 'click', () => console.log('button clicked'), this);
 ```
 <a name="toggleClass"></a>
 
-## toggleClass
-toggles given class on given element
+## toggleClass(elements, className, add)
+<p>toggles given class on given element</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -586,73 +643,161 @@ toggles given class on given element
 
 **Example**  
 ```js
-const button = find(document, 'button');onEvent(button, 'click', () => toggleClass(button, 'active'), this);
+const button = find(document, 'button');
+onEvent(button, 'click', () => toggleClass(button, 'active'), this);
 ```
 <a name="waitFor"></a>
 
-## waitFor ⇒ <code>Promise.&lt;void&gt;</code>
-resolves Promise after given timeout
+## waitFor(timeout) ⇒ <code>Promise.&lt;void&gt;</code>
+<p>resolves Promise after given timeout</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| timeout | <code>number</code> | timeout in milliseconds |
+| timeout | <code>number</code> | <p>timeout in milliseconds</p> |
 
 **Example**  
 ```js
-addClass(button, 'animate');waitFor(300).then(() => removeClass(button, 'animate'));
+addClass(button, 'animate');
+waitFor(300).then(() => removeClass(button, 'animate'));
 ```
 **Example**  
 ```js
-addClass(button, 'animate');await waitFor(300);removeClass(button, 'animate');
+addClass(button, 'animate');
+await waitFor(300);
+removeClass(button, 'animate');
 ```
 <a name="waitForEvent"></a>
 
-## waitForEvent ⇒ <code>Promise.&lt;void&gt;</code>
-waits for given event for a (optional) max-timeout
+## waitForEvent(target, eventName, timeout) ⇒ <code>Promise.&lt;void&gt;</code>
+<p>waits for given event for a (optional) max-timeout</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | target | <code>HTMLElement</code> |  |
 | eventName | <code>string</code> |  |
-| timeout | <code>number</code> | timeout in milliseconds |
+| timeout | <code>number</code> | <p>timeout in milliseconds</p> |
 
 **Example**  
 ```js
-addClass(button, 'animate');waitForEvent(button, 'transitionend', 500).then(() => removeClass(button, 'animate'));
+addClass(button, 'animate');
+waitForEvent(button, 'transitionend', 500).then(() => removeClass(button, 'animate'));
 ```
 **Example**  
 ```js
-addClass(button, 'animate');await waitForEvent(button, 'transitionend', 500);removeClass(button, 'animate');
+addClass(button, 'animate');
+await waitForEvent(button, 'transitionend', 500);
+removeClass(button, 'animate');
 ```
-<a name="getValue"></a>
+<a name="debounce"></a>
 
-## ~~getValue ⇒ <code>\*</code>~~
-***Deprecated***
+## debounce(callback, [wait]) ⇒ <code>function</code>
+<p>returns a debounced function which when called multiple of times each time it waits the waiting duration
+and if the method was not called during this time, the last call will be passed to the callback.</p>
 
-returns nested value without throwing an error if the parent doesn't exist
+**Kind**: global function  
+**Debounce(100)**: scrollHandler(event) {
+      // ...
+     }
+  }  
 
-**Kind**: global constant  
-**Returns**: <code>\*</code> - - returned the found value or undefined  
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| callback | <code>function</code> |  | <p>function to be called after the last wait period</p> |
+| [wait] | <code>number</code> | <code>0</code> | <p>waiting period in ms before the callback is invoked if during this time the debounced method was not called</p> |
+
+**Example**  
+```js
+const debounced = debounce(console.log, 500);
+  debonced("Hi");
+  debonced("Hello");
+  debonced("Hey");
+  if (neverMind) debonced.cancel();
+  // logs only "Hey", and when `neverMind === false`, doesn't log anything.
+
+
+  // or instead of decorator on class methods
+  Class Component {
+    constructor() {
+      window.addEventListener("resize", this.resizeHandler);
+      window.addEventListener("scroll", this.scrollHandler);
+    }
+
+    resizeHandler = debounce(event => {
+      // event handlers logic
+    }, 100);
+
+    // or when the decorator is imported:
+    
+```
+<a name="decoratorGenerator"></a>
+
+## decoratorGenerator(func) ⇒ <code>function</code>
+<p>generates a decorator factory for the provided helper function.
+helper function should have this signature: <code>(Function, ...args: any[]) =&gt; Function</code></p>
+
+**Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| obj | <code>Object</code> | object to be looked for value |
-| path | <code>string</code> | a string with dot separated levels: e.g "a.b" |
+| func | <code>function</code> | <p>function to be wrapped with a decorator factory</p> |
+
+<a name="throttle"></a>
+
+## throttle(callback, [wait]) ⇒ <code>function</code>
+<p>returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.
+call <code>.cancel()</code> on the returned function, to cancel the callback invocation.</p>
+
+**Kind**: global function  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| callback | <code>function</code> |  | <p>function to be caled after the last wait period</p> |
+| [wait] | <code>number</code> | <code>0</code> | <p>waiting period in ms before the callback is invoked if during this time the debounced method was not called</p> |
 
 **Example**  
 ```js
-const obj = {  a: {    b: {      c: 1    },    d: true  }};getValue(obj, "a.b") === {c: 1};getValue(obj, "a.f") === undefined;
+window.addEventListener("resize", throttle(updateSlider, 100));
+```
+<a name="getValue"></a>
+
+## ~~getValue(obj, path) ⇒ <code>\*</code>~~
+***Deprecated***
+
+<p>returns nested value without throwing an error if the parent doesn't exist</p>
+
+**Kind**: global function  
+**Returns**: <code>\*</code> - <ul>
+<li>returned the found value or undefined</li>
+</ul>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| obj | <code>Object</code> | <p>object to be looked for value</p> |
+| path | <code>string</code> | <p>a string with dot separated levels: e.g &quot;a.b&quot;</p> |
+
+**Example**  
+```js
+const obj = {
+  a: {
+    b: {
+      c: 1
+    },
+    d: true
+  }
+};
+getValue(obj, "a.b") === {c: 1};
+getValue(obj, "a.f") === undefined;
 ```
 <a name="isEqual"></a>
 
-## isEqual ⇒ <code>boolean</code>
-compare two arguments, for object their toString values are compared
+## isEqual(arg1, arg2) ⇒ <code>boolean</code>
+<p>compare two arguments, for object their toString values are compared</p>
 
-**Kind**: global constant  
+**Kind**: global function  
 
 | Param | Type |
 | --- | --- |
@@ -663,170 +808,10 @@ compare two arguments, for object their toString values are compared
 ```js
 if (!isEqual(oldState, newState)) console.log('state changed');
 ```
-<a name="toArray"></a>
-
-## toArray ⇒ <code>Array.&lt;T&gt;</code>
-returns the argument wrapped in an array if it isn't array itself
-
-**Kind**: global constant  
-
-| Param | Type |
-| --- | --- |
-| arg | <code>T</code> \| <code>Array.&lt;T&gt;</code> | 
-
-**Example**  
-```js
-const apple = "Apple";const fruits = toArray(apple); // ["Apple"]
-```
-<a name="toString"></a>
-
-## toString ⇒ <code>string</code>
-returns stringified value for the given argument
-
-**Kind**: global constant  
-
-| Param | Type |
-| --- | --- |
-| arg | <code>\*</code> | 
-
-**Example**  
-```js
-const submitData = toString(formData);
-```
-<a name="getCleanString"></a>
-
-## getCleanString ⇒ <code>string</code>
-removes all multi Whitespaces and Newlines in given string
-
-**Kind**: global constant  
-
-| Param | Type |
-| --- | --- |
-| inputString | <code>string</code> | 
-
-**Example**  
-```js
-const article = find(document, 'aricle');const text = getCleanString(article.innerText);
-```
-<a name="getWordCount"></a>
-
-## getWordCount ⇒ <code>number</code>
-returns number of words in a given text
-
-**Kind**: global constant  
-
-| Param | Type |
-| --- | --- |
-| text | <code>string</code> | 
-
-**Example**  
-```js
-const article = find(document, 'aricle');const articleWords = getWordCount(article.innerText);
-```
-<a name="removeAllBS"></a>
-
-## removeAllBS ⇒ <code>string</code>
-removes all Whitespaces in given string
-
-**Kind**: global constant  
-
-| Param | Type |
-| --- | --- |
-| inputString | <code>string</code> | 
-
-**Example**  
-```js
-removeAllBS('Hello My  World  '); // HelloMyWorld
-```
-<a name="removeAllNL"></a>
-
-## removeAllNL ⇒ <code>string</code>
-removes all Newlines in given string
-
-**Kind**: global constant  
-
-| Param | Type |
-| --- | --- |
-| inputString | <code>string</code> | 
-
-**Example**  
-```js
-const article = find(document, 'aricle');const textString = removeAllNL(article.innerText);
-```
-<a name="removeMultiBS"></a>
-
-## removeMultiBS ⇒ <code>string</code>
-removes multi Whitespaces in given string
-
-**Kind**: global constant  
-
-| Param | Type |
-| --- | --- |
-| inputString | <code>string</code> | 
-
-**Example**  
-```js
-removeMultiBS('Hello My      World'); // Hello My World
-```
-<a name="callback"></a>
-
-## callback(node, index) ⇒
-**Kind**: global function  
-**Returns**: any  
-
-| Param | Type |
-| --- | --- |
-| node | <code>Node</code> | 
-| index | <code>Number</code> | 
-
-<a name="debounce"></a>
-
-## debounce(callback, [wait]) ⇒ <code>function</code>
-returns a debounced function which when called multiple of times each time it waits the waiting durationand if the method was not called during this time, the last call will be passed to the callback.
-
-**Kind**: global function  
-**Debounce(100)**: scrollHandler(event) {      // ...     }  }  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| callback | <code>function</code> |  | function to be called after the last wait period |
-| [wait] | <code>number</code> | <code>0</code> | waiting period in ms before the callback is invoked if during this time the debounced method was not called |
-
-**Example**  
-```js
-const debounced = debounce(console.log, 500);  debonced("Hi");  debonced("Hello");  debonced("Hey");  if (neverMind) debonced.cancel();  // logs only "Hey", and when `neverMind === false`, doesn't log anything.  // or instead of decorator on class methods  Class Component {    constructor() {      window.addEventListener("resize", this.resizeHandler);      window.addEventListener("scroll", this.scrollHandler);    }    resizeHandler = debounce(event => {      // event handlers logic    }, 100);    // or when the decorator is imported:    
-```
-<a name="decoratorGenerator"></a>
-
-## decoratorGenerator(func) ⇒ <code>function</code>
-generates a decorator factory for the provided helper function.helper function should have this signature: `(Function, ...args: any[]) => Function`
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| func | <code>function</code> | function to be wrapped with a decorator factory |
-
-<a name="throttle"></a>
-
-## throttle(callback, [wait]) ⇒ <code>function</code>
-returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.call `.cancel()` on the returned function, to cancel the callback invocation.
-
-**Kind**: global function  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| callback | <code>function</code> |  | function to be caled after the last wait period |
-| [wait] | <code>number</code> | <code>0</code> | waiting period in ms before the callback is invoked if during this time the debounced method was not called |
-
-**Example**  
-```js
-window.addEventListener("resize", throttle(updateSlider, 100));
-```
 <a name="naiveClone"></a>
 
 ## naiveClone(arg) ⇒ <code>Nullable.&lt;T&gt;</code> \| <code>Array.&lt;T&gt;</code>
-returns a deep link of the provided argument
+<p>returns a deep link of the provided argument</p>
 
 **Kind**: global function  
 
@@ -838,25 +823,135 @@ returns a deep link of the provided argument
 ```js
 const state = naiveClone(initialState);
 ```
+<a name="toArray"></a>
+
+## toArray(arg) ⇒ <code>Array.&lt;T&gt;</code>
+<p>returns the argument wrapped in an array if it isn't array itself</p>
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| arg | <code>T</code> \| <code>Array.&lt;T&gt;</code> | 
+
+**Example**  
+```js
+const apple = "Apple";
+const fruits = toArray(apple); // ["Apple"] 
+```
+<a name="toString"></a>
+
+## toString(arg) ⇒ <code>string</code>
+<p>returns stringified value for the given argument</p>
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| arg | <code>\*</code> | 
+
+**Example**  
+```js
+const submitData = toString(formData);
+```
+<a name="getCleanString"></a>
+
+## getCleanString(inputString) ⇒ <code>string</code>
+<p>removes all multi Whitespaces and Newlines in given string</p>
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| inputString | <code>string</code> | 
+
+**Example**  
+```js
+const article = find(document, 'aricle');
+const text = getCleanString(article.innerText);
+```
+<a name="getWordCount"></a>
+
+## getWordCount(text) ⇒ <code>number</code>
+<p>returns number of words in a given text</p>
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| text | <code>string</code> | 
+
+**Example**  
+```js
+const article = find(document, 'aricle');
+const articleWords = getWordCount(article.innerText);
+```
+<a name="removeAllBS"></a>
+
+## removeAllBS(inputString) ⇒ <code>string</code>
+<p>removes all Whitespaces in given string</p>
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| inputString | <code>string</code> | 
+
+**Example**  
+```js
+removeAllBS('Hello My  World  '); // HelloMyWorld
+```
+<a name="removeAllNL"></a>
+
+## removeAllNL(inputString) ⇒ <code>string</code>
+<p>removes all Newlines in given string</p>
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| inputString | <code>string</code> | 
+
+**Example**  
+```js
+const article = find(document, 'aricle');
+const textString = removeAllNL(article.innerText);
+```
+<a name="removeMultiBS"></a>
+
+## removeMultiBS(inputString) ⇒ <code>string</code>
+<p>removes multi Whitespaces in given string</p>
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| inputString | <code>string</code> | 
+
+**Example**  
+```js
+removeMultiBS('Hello My      World'); // Hello My World
+```
 <a name="toCamelCase"></a>
 
 ## toCamelCase(str) ⇒ <code>string</code>
-function to convert texts to camelCase for example ti generate attribute names
+<p>function to convert texts to camelCase for example ti generate attribute names</p>
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| str | <code>string</code> | sequence of letters, dashes and spaces to be converted to camelCase |
+| str | <code>string</code> | <p>sequence of letters, dashes and spaces to be converted to camelCase</p> |
 
 **Example**  
 ```js
-toCamelCase("some-text") === "someText";toCamelCase("some other text") === "someOtherText";
+toCamelCase("some-text") === "someText";
+toCamelCase("some other text") === "someOtherText";
 ```
 <a name="toKebabCase"></a>
 
 ## toKebabCase(str) ⇒ <code>string</code>
-converts the provided string to a kebab case (kebab-case)
+<p>converts the provided string to a kebab case (kebab-case)</p>
 
 **Kind**: global function  
 
@@ -871,7 +966,8 @@ toKebabCase("keyValuePair") === "key-value-pair"
 <a name="callback"></a>
 
 ## callback : <code>function</code>
-iterates over all nodes in a node list(necessary because IE11 doesn't support .forEach  * for NodeLists)
+<p>iterates over all nodes in a node list
+(necessary because IE11 doesn't support .forEach  * for NodeLists)</p>
 
 **Kind**: global typedef  
 
@@ -882,7 +978,8 @@ iterates over all nodes in a node list(necessary because IE11 doesn't support .
 
 **Example**  
 ```js
-const buttons = document.querySelectorAll('button');forEachNode(buttons, (button, idx) => addClass(button, `my-button--${idx}`))
+const buttons = document.querySelectorAll('button');
+forEachNode(buttons, (button, idx) => addClass(button, `my-button--${idx}`))
 ```
 
 

--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -2,7 +2,7 @@
 <p>
   <img alt="Version" src="https://img.shields.io/badge/version-0.1.0-blue.svg?cacheSeconds=2592000" />
   <a href="#" target="_blank">
-    <img alt="License: (Apache)" src="https://img.shields.io/badge/License-Apache_2.0-yellow.svg" />
+    <img alt="License: ISC" src="https://img.shields.io/badge/License-ISC-yellow.svg" />
   </a>
 </p>
 
@@ -143,9 +143,13 @@ Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p>
 <dd><p>returns a debounced function which when called multiple of times each time it waits the waiting duration
 and if the method was not called during this time, the last call will be passed to the callback.</p>
 </dd>
+<dt><a href="#decoratorGenerator">decoratorGenerator(func)</a> ⇒ <code>function</code></dt>
+<dd><p>generates a decorator factory for the provided helper function.
+helper function should have this signature: <code>(Function, ...args: any[]) =&gt; Function</code></p>
+</dd>
 <dt><a href="#throttle">throttle(callback, [wait])</a> ⇒ <code>function</code></dt>
 <dd><p>returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.
-call <code>.cancel()</code> on the returned function, to cancel the callback invokation.</p>
+call <code>.cancel()</code> on the returned function, to cancel the callback invocation.</p>
 </dd>
 <dt><a href="#naiveClone">naiveClone(arg)</a> ⇒ <code>Nullable.&lt;T&gt;</code> | <code>Array.&lt;T&gt;</code></dt>
 <dd><p>returns a deep link of the provided argument</p>
@@ -181,13 +185,11 @@ Calls API and returns JSON as Promise
 
 **Example**  
 ```js
-// use with async/await
-const myApiResponse = await fetchJSON("https://some.api/path")
+// use with async/awaitconst myApiResponse = await fetchJSON("https://some.api/path")
 ```
 **Example**  
 ```js
-// use as normal promise
-fetchJSON("https://some.api/path").then((data) => console.log("myData:", data));
+// use as normal promisefetchJSON("https://some.api/path").then((data) => console.log("myData:", data));
 ```
 <a name="hasElement"></a>
 
@@ -203,11 +205,7 @@ checks, if element is in given array
 
 **Example**  
 ```js
-const fruits = ["Banana", "Orange", "Apple", "Mango"];
-
-if (hasElement(fruits, "Apple")) {
-  console.log("You got an Apple");
-}
+const fruits = ["Banana", "Orange", "Apple", "Mango"];if (hasElement(fruits, "Apple")) {  console.log("You got an Apple");}
 ```
 <a name="isFilledArray"></a>
 
@@ -222,12 +220,7 @@ checks, whether given Array exists and has at least one element
 
 **Example**  
 ```js
-const myBooks = await fetchJSON("https://my-book-store.api/books");
-if (isFilledArray(myBooks)) {
-  console.log(`${myBooks.length} Books found!`)
-} else {
-  console.log("Sorry, no Books found");
-}
+const myBooks = await fetchJSON("https://my-book-store.api/books");if (isFilledArray(myBooks)) {  console.log(`${myBooks.length} Books found!`)} else {  console.log("Sorry, no Books found");}
 ```
 <a name="mergeArraysBy"></a>
 
@@ -244,55 +237,7 @@ merge two given arrays by the given checker function
 
 **Example**  
 ```js
-const defaultUsers = [
-  {
-    name: "Admin",
-    mail: "admin@company.com"
-  },
-  {
-    name: "CI",
-    mail: "ci@company.com"
-  }
-];
-
-const projectUsers = [
-  {
-    name: "Admin",
-    mail: "admin@company.com"
-  },
-  {
-    name: "User1",
-    mail: "user-one@company.com"
-  },
-  {
-    name: "User2",
-    mail: "user-two@company.com"
-  }
-];
-
-const userList = mergeArraysBy(defaultUsers, projectUsers, (defaultUser, array) => {
-  return !array.some((projectUser) => projectUser.mail === defaultUser.mail)
-})
-
-// userList
-// [
-//   {
-//     "name": "CI",
-//     "mail": "ci@company.com"
-//   },
-//   {
-//     "name": "Admin",
-//     "mail": "admin@company.com"
-//   },
-//   {
-//     "name": "User1",
-//     "mail": "user-one@company.com"
-//   },
-//   {
-//     "name": "User2",
-//     "mail": "user-two@company.com"
-//   }
-// ]
+const defaultUsers = [  {    name: "Admin",    mail: "admin@company.com"  },  {    name: "CI",    mail: "ci@company.com"  }];const projectUsers = [  {    name: "Admin",    mail: "admin@company.com"  },  {    name: "User1",    mail: "user-one@company.com"  },  {    name: "User2",    mail: "user-two@company.com"  }];const userList = mergeArraysBy(defaultUsers, projectUsers, (defaultUser, array) => {  return !array.some((projectUser) => projectUser.mail === defaultUser.mail)})// userList// [//   {//     "name": "CI",//     "mail": "ci@company.com"//   },//   {//     "name": "Admin",//     "mail": "admin@company.com"//   },//   {//     "name": "User1",//     "mail": "user-one@company.com"//   },//   {//     "name": "User2",//     "mail": "user-two@company.com"//   }// ]
 ```
 <a name="pushIfNew"></a>
 
@@ -308,9 +253,7 @@ pushes new Element to given array, if its not already in it
 
 **Example**  
 ```js
-const fruitStore = ["Banana", "Orange", "Apple", "Mango"];
-const newFruit = getInputValue(...)
-const newFruitStore = pushIfNew(fruitStore, newFruit);
+const fruitStore = ["Banana", "Orange", "Apple", "Mango"];const newFruit = getInputValue(...)const newFruitStore = pushIfNew(fruitStore, newFruit);
 ```
 <a name="removeItem"></a>
 
@@ -326,8 +269,7 @@ removes specific Item from array and return new array
 
 **Example**  
 ```js
-const fruitStore = ["Banana", "Orange", "Apple", "Mango"];
-const newFruitStore = removeItem(fruitStore, "Apple"); // ["Banana", "Orange", "Mango"]
+const fruitStore = ["Banana", "Orange", "Apple", "Mango"];const newFruitStore = removeItem(fruitStore, "Apple"); // ["Banana", "Orange", "Mango"]
 ```
 <a name="addDays"></a>
 
@@ -344,8 +286,7 @@ Adds given amount of days to given date
 
 **Example**  
 ```js
-const today = new Date();
-const tomorrow = addDays(today, 2);
+const today = new Date();const tomorrow = addDays(today, 2);
 ```
 <a name="addLeadingZero"></a>
 
@@ -360,8 +301,7 @@ Optionally Adds leading Zero to Numbers < 10
 
 **Example**  
 ```js
-const today = new Date();
-const formattedDateSting = `${addLeadingZero(today.getDate())}.${addLeadingZero(today.getMonth() + 1)}.${today.getFullYear()}`;
+const today = new Date();const formattedDateSting = `${addLeadingZero(today.getDate())}.${addLeadingZero(today.getMonth() + 1)}.${today.getFullYear()}`;
 ```
 <a name="isEqualDate"></a>
 
@@ -377,18 +317,12 @@ Checks whether given dates are equal
 
 **Example**  
 ```js
-const dateA = new Date(2020, 1, 29, 22, 30);
-const dateB = new Date(2020, 1, 29, 18, 20);
-isEqualDate(dateA. dateB); // true
+const dateA = new Date(2020, 1, 29, 22, 30);const dateB = new Date(2020, 1, 29, 18, 20);isEqualDate(dateA. dateB); // true
 ```
 <a name="sanitizeDateGMTOffset"></a>
 
 ## sanitizeDateGMTOffset ⇒ <code>string</code>
-Helper to make date parsing cross browser compatible
-Some browsers (e.g. Safari) need the GMT offset part to be in format "+00:00"
-This helper makes sure that any present GMT offset follows that format and can safely be parsed:
-Date.parse("2020-01-01T12:13:14.000+0200") // throws error in Safari
-Date.parse("2020-01-01T12:13:14.000+02:00") // succes
+Helper to make date parsing cross browser compatibleSome browsers (e.g. Safari) need the GMT offset part to be in format "+00:00"This helper makes sure that any present GMT offset follows that format and can safely be parsed:Date.parse("2020-01-01T12:13:14.000+0200") // throws error in SafariDate.parse("2020-01-01T12:13:14.000+02:00") // succes
 
 **Kind**: global constant  
 **Returns**: <code>string</code> - correctly formatted date  
@@ -415,13 +349,11 @@ adds given classes to one or multiple elements
 
 **Example**  
 ```js
-const button = document.querySelector('.button');
-addClass(button, 'my-button');
+const button = document.querySelector('.button');addClass(button, 'my-button');
 ```
 **Example**  
 ```js
-const inputs = document.querySelectorAll('input');
-addClass(inputs, 'my-button');
+const inputs = document.querySelectorAll('input');addClass(inputs, 'my-button');
 ```
 <a name="find"></a>
 
@@ -469,18 +401,7 @@ returns current mediaQuery-name. e.g. "MQ2"
 
 **Example**  
 ```js
-const myMqs = [
-  {
-    name: 'MQ2',
-    query: '(min-width: 769px)'
-  },
-  {
-    name: 'MQ1',
-    query: '(min-width: 0px)'
-  }
-];
-
-const curMQ = getCurrentMQ(myMqs);
+const myMqs = [  {    name: 'MQ2',    query: '(min-width: 769px)'  },  {    name: 'MQ1',    query: '(min-width: 0px)'  }];const curMQ = getCurrentMQ(myMqs);
 ```
 <a name="getInnerText"></a>
 
@@ -495,8 +416,7 @@ returns innerText of given Element
 
 **Example**  
 ```js
-const myArticle = document.querySelector('article');
-const articleText = getInnerText(myArticle);
+const myArticle = document.querySelector('article');const articleText = getInnerText(myArticle);
 ```
 <a name="getParent"></a>
 
@@ -512,8 +432,7 @@ returns parent of specific class, if found
 
 **Example**  
 ```js
-const myText = document.querySelector('p');
-const myArticle = getParent(myText, 'article');
+const myText = document.querySelector('p');const myArticle = getParent(myText, 'article');
 ```
 <a name="getUniqueID"></a>
 
@@ -535,8 +454,7 @@ returns if a specific parent has a child matching the given selector
 
 **Example**  
 ```js
-const article = document.querySelector('article');
-if (hasChild(article, '.cta')) console.log('please click');
+const article = document.querySelector('article');if (hasChild(article, '.cta')) console.log('please click');
 ```
 <a name="hasClass"></a>
 
@@ -552,8 +470,7 @@ returns if a specific element has given class
 
 **Example**  
 ```js
-const cta = document.querySelector('button');
-if (hasClass(cta, 'primary')) console.log("primary")
+const cta = document.querySelector('button');if (hasClass(cta, 'primary')) console.log("primary")
 ```
 <a name="inViewport"></a>
 
@@ -569,8 +486,7 @@ checks, whether an element is in the viewport
 
 **Example**  
 ```js
-const image = document.querySelector('image');
-if (inViewport(image)) image.setAttribute('src', image.dataset('src'));
+const image = document.querySelector('image');if (inViewport(image)) image.setAttribute('src', image.dataset('src'));
 ```
 <a name="isNodeList"></a>
 
@@ -599,8 +515,7 @@ adds event with given parameters
 
 **Example**  
 ```js
-const buttons = findAll(document, 'button);
-onEvent(buttons, 'click', () => console.log('button clicked'), this);
+const buttons = findAll(document, 'button);onEvent(buttons, 'click', () => console.log('button clicked'), this);
 ```
 <a name="removeChildren"></a>
 
@@ -616,8 +531,7 @@ removes all children of a specific parent matching the given selector
 
 **Example**  
 ```js
-const article = find('article);
-removeChildren(article, '.ad');
+const article = find('article);removeChildren(article, '.ad');
 ```
 <a name="removeClass"></a>
 
@@ -633,13 +547,11 @@ removes given class from element
 
 **Example**  
 ```js
-const button = document.querySelector('.button');
-removeClass(button, 'active');
+const button = document.querySelector('.button');removeClass(button, 'active');
 ```
 **Example**  
 ```js
-const inputs = document.querySelectorAll('input');
-removeClass(inputs, 'active');
+const inputs = document.querySelectorAll('input');removeClass(inputs, 'active');
 ```
 <a name="removeEvent"></a>
 
@@ -657,8 +569,7 @@ removes event with given parameters
 
 **Example**  
 ```js
-const buttons = findAll(document, 'button);
-removeEvent(buttons, 'click', () => console.log('button clicked'), this);
+const buttons = findAll(document, 'button);removeEvent(buttons, 'click', () => console.log('button clicked'), this);
 ```
 <a name="toggleClass"></a>
 
@@ -675,8 +586,7 @@ toggles given class on given element
 
 **Example**  
 ```js
-const button = find(document, 'button');
-onEvent(button, 'click', () => toggleClass(button, 'active'), this);
+const button = find(document, 'button');onEvent(button, 'click', () => toggleClass(button, 'active'), this);
 ```
 <a name="waitFor"></a>
 
@@ -691,14 +601,11 @@ resolves Promise after given timeout
 
 **Example**  
 ```js
-addClass(button, 'animate');
-waitFor(300).then(() => removeClass(button, 'animate'));
+addClass(button, 'animate');waitFor(300).then(() => removeClass(button, 'animate'));
 ```
 **Example**  
 ```js
-addClass(button, 'animate');
-await waitFor(300);
-removeClass(button, 'animate');
+addClass(button, 'animate');await waitFor(300);removeClass(button, 'animate');
 ```
 <a name="waitForEvent"></a>
 
@@ -715,14 +622,11 @@ waits for given event for a (optional) max-timeout
 
 **Example**  
 ```js
-addClass(button, 'animate');
-waitForEvent(button, 'transitionend', 500).then(() => removeClass(button, 'animate'));
+addClass(button, 'animate');waitForEvent(button, 'transitionend', 500).then(() => removeClass(button, 'animate'));
 ```
 **Example**  
 ```js
-addClass(button, 'animate');
-await waitForEvent(button, 'transitionend', 500);
-removeClass(button, 'animate');
+addClass(button, 'animate');await waitForEvent(button, 'transitionend', 500);removeClass(button, 'animate');
 ```
 <a name="getValue"></a>
 
@@ -741,16 +645,7 @@ returns nested value without throwing an error if the parent doesn't exist
 
 **Example**  
 ```js
-const obj = {
-  a: {
-    b: {
-      c: 1
-    },
-    d: true
-  }
-};
-getValue(obj, "a.b") === {c: 1};
-getValue(obj, "a.f") === undefined;
+const obj = {  a: {    b: {      c: 1    },    d: true  }};getValue(obj, "a.b") === {c: 1};getValue(obj, "a.f") === undefined;
 ```
 <a name="isEqual"></a>
 
@@ -781,8 +676,7 @@ returns the argument wrapped in an array if it isn't array itself
 
 **Example**  
 ```js
-const apple = "Apple";
-const fruits = toArray(apple); // ["Apple"]
+const apple = "Apple";const fruits = toArray(apple); // ["Apple"]
 ```
 <a name="toString"></a>
 
@@ -812,8 +706,7 @@ removes all multi Whitespaces and Newlines in given string
 
 **Example**  
 ```js
-const article = find(document, 'aricle');
-const text = getCleanString(article.innerText);
+const article = find(document, 'aricle');const text = getCleanString(article.innerText);
 ```
 <a name="getWordCount"></a>
 
@@ -828,8 +721,7 @@ returns number of words in a given text
 
 **Example**  
 ```js
-const article = find(document, 'aricle');
-const articleWords = getWordCount(article.innerText);
+const article = find(document, 'aricle');const articleWords = getWordCount(article.innerText);
 ```
 <a name="removeAllBS"></a>
 
@@ -859,8 +751,7 @@ removes all Newlines in given string
 
 **Example**  
 ```js
-const article = find(document, 'aricle');
-const textString = removeAllNL(article.innerText);
+const article = find(document, 'aricle');const textString = removeAllNL(article.innerText);
 ```
 <a name="removeMultiBS"></a>
 
@@ -891,42 +782,35 @@ removeMultiBS('Hello My      World'); // Hello My World
 <a name="debounce"></a>
 
 ## debounce(callback, [wait]) ⇒ <code>function</code>
-returns a debounced function which when called multiple of times each time it waits the waiting duration
-and if the method was not called during this time, the last call will be passed to the callback.
+returns a debounced function which when called multiple of times each time it waits the waiting durationand if the method was not called during this time, the last call will be passed to the callback.
 
 **Kind**: global function  
+**Debounce(100)**: scrollHandler(event) {      // ...     }  }  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| callback | <code>function</code> |  | function to be caled after the last wait period |
+| callback | <code>function</code> |  | function to be called after the last wait period |
 | [wait] | <code>number</code> | <code>0</code> | waiting period in ms before the callback is invoked if during this time the debounced method was not called |
 
 **Example**  
 ```js
-const debounced = debounce(console.log, 500);
-  debonced("Hi");
-  debonced("Hello");
-  debonced("Hey");
-  if (neverMind) debonced.cancel;
-  // logs only "Hey"
-
-
-  // or instead of decorator on class methods
-  Class Component {
-    constructor() {
-         window.addEventListener("resize", this.resizeHandler);
-    }
-
-    resizeHandler = throttle(event => {
-      // event handlers logic
-    }, 100);
-  }
+const debounced = debounce(console.log, 500);  debonced("Hi");  debonced("Hello");  debonced("Hey");  if (neverMind) debonced.cancel();  // logs only "Hey", and when `neverMind === false`, doesn't log anything.  // or instead of decorator on class methods  Class Component {    constructor() {      window.addEventListener("resize", this.resizeHandler);      window.addEventListener("scroll", this.scrollHandler);    }    resizeHandler = debounce(event => {      // event handlers logic    }, 100);    // or when the decorator is imported:    
 ```
+<a name="decoratorGenerator"></a>
+
+## decoratorGenerator(func) ⇒ <code>function</code>
+generates a decorator factory for the provided helper function.helper function should have this signature: `(Function, ...args: any[]) => Function`
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| func | <code>function</code> | function to be wrapped with a decorator factory |
+
 <a name="throttle"></a>
 
 ## throttle(callback, [wait]) ⇒ <code>function</code>
-returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.
-call `.cancel()` on the returned function, to cancel the callback invokation.
+returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.call `.cancel()` on the returned function, to cancel the callback invocation.
 
 **Kind**: global function  
 
@@ -967,8 +851,7 @@ function to convert texts to camelCase for example ti generate attribute names
 
 **Example**  
 ```js
-toCamelCase("some-text") === "someText";
-toCamelCase("some other text") === "someOtherText";
+toCamelCase("some-text") === "someText";toCamelCase("some other text") === "someOtherText";
 ```
 <a name="toKebabCase"></a>
 
@@ -988,8 +871,7 @@ toKebabCase("keyValuePair") === "key-value-pair"
 <a name="callback"></a>
 
 ## callback : <code>function</code>
-iterates over all nodes in a node list
-(necessary because IE11 doesn't support .forEach  * for NodeLists)
+iterates over all nodes in a node list(necessary because IE11 doesn't support .forEach  * for NodeLists)
 
 **Kind**: global typedef  
 
@@ -1000,8 +882,7 @@ iterates over all nodes in a node list
 
 **Example**  
 ```js
-const buttons = document.querySelectorAll('button');
-forEachNode(buttons, (button, idx) => addClass(button, `my-button--${idx}`))
+const buttons = document.querySelectorAll('button');forEachNode(buttons, (button, idx) => addClass(button, `my-button--${idx}`))
 ```
 
 

--- a/packages/js-utils/README.template.md
+++ b/packages/js-utils/README.template.md
@@ -2,7 +2,7 @@
 <p>
   <img alt="Version" src="https://img.shields.io/badge/version-0.1.0-blue.svg?cacheSeconds=2592000" />
   <a href="#" target="_blank">
-    <img alt="License: ISC" src="https://img.shields.io/badge/License-ISC-yellow.svg" />
+    <img alt="License: Apache 2.0" src="https://img.shields.io/badge/License-Apache_2.0-yellow.svg" />
   </a>
 </p>
 

--- a/packages/js-utils/build.js
+++ b/packages/js-utils/build.js
@@ -44,6 +44,13 @@ const bundles = {
       module: 'lib/function-helpers/index.module.js',
     },
   },
+  "functionHelpers/decorators": {
+    inputPath: './src/function-helpers/decorators.ts',
+    outFiles: {
+      main: 'lib/function-helpers/decorators/index.js',
+      module: 'lib/function-helpers/decorators/index.module.js',
+    },
+  },
   objectHelpers: {
     inputPath: './src/object-helpers/index.ts',
     outFiles: {

--- a/packages/js-utils/package.json
+++ b/packages/js-utils/package.json
@@ -30,6 +30,7 @@
     "build:dateHelpers": "rollup -c build.js --environment TARGET:dateHelpers",
     "build:domHelpers": "rollup -c build.js --environment TARGET:domHelpers",
     "build:functionHelpers": "rollup -c build.js --environment TARGET:functionHelpers",
+    "build:functionHelpers/decorators": "rollup -c build.js --environment TARGET:functionHelpers/decorators",
     "build:objectHelpers": "rollup -c build.js --environment TARGET:objectHelpers",
     "build:stringHelpers": "rollup -c build.js --environment TARGET:stringHelpers",
     "test": "jest"

--- a/packages/js-utils/src/function-helpers/decorators.ts
+++ b/packages/js-utils/src/function-helpers/decorators.ts
@@ -1,0 +1,1 @@
+export * from './lib/decorators';

--- a/packages/js-utils/src/function-helpers/lib/debounce.ts
+++ b/packages/js-utils/src/function-helpers/lib/debounce.ts
@@ -7,22 +7,29 @@
  *   debonced("Hi");
  *   debonced("Hello");
  *   debonced("Hey");
- *   if (neverMind) debonced.cancel;
- *   // logs only "Hey"
+ *   if (neverMind) debonced.cancel();
+ *   // logs only "Hey", and when `neverMind === false`, doesn't log anything.
  *
  *
  *   // or instead of decorator on class methods
  *   Class Component {
  *     constructor() {
- *          window.addEventListener("resize", this.resizeHandler);
+ *       window.addEventListener("resize", this.resizeHandler);
+ *       window.addEventListener("scroll", this.scrollHandler);
  *     }
  *
- *     resizeHandler = throttle(event => {
+ *     resizeHandler = debounce(event => {
  *       // event handlers logic
  *     }, 100);
+ *
+ *     // or when the decorator is imported:
+ *     @debounce(100)
+ *     scrollHandler(event) {
+ *       // ...
+*      }
  *   }
  *
- * @param {Function} callback - function to be caled after the last wait period
+ * @param {Function} callback - function to be called after the last wait period
  * @param {number} [wait=0] - waiting period in ms before the callback is invoked if during this time the debounced method was not called
  * @returns {Function}
  */

--- a/packages/js-utils/src/function-helpers/lib/decorators/decoratorGenerator.ts
+++ b/packages/js-utils/src/function-helpers/lib/decorators/decoratorGenerator.ts
@@ -1,0 +1,19 @@
+/**
+ * generates a decorator factory for the provided helper function.
+ * helper function should have this signature: `(Function, ...args: any[]) => Function`
+ *
+ * @export
+ * @param {Function} func - function to be wrapped with a decorator factory
+ * @returns {Function}
+ */
+export function decoratorGenerator(func: Function): Function {
+  // arguments passed to the decorator
+  return function (...args: any[]) {
+    return function decorator(_proto: any, _methodName: string, descriptor: PropertyDescriptor) {
+      return {
+        ...descriptor,
+        value: func(descriptor.value, ...args),
+      }
+    }
+  }
+}

--- a/packages/js-utils/src/function-helpers/lib/decorators/decoratorGenerator.ts
+++ b/packages/js-utils/src/function-helpers/lib/decorators/decoratorGenerator.ts
@@ -8,8 +8,8 @@
  */
 export function decoratorGenerator(func: Function): Function {
   // arguments passed to the decorator
-  return function (...args: any[]) {
-    return function decorator(_proto: any, _methodName: string, descriptor: PropertyDescriptor) {
+  return function (...args: any[]): MethodDecorator {
+    return function decorator(_proto: any, _methodName: string | symbol, descriptor: PropertyDescriptor) {
       return {
         ...descriptor,
         value: func(descriptor.value, ...args),

--- a/packages/js-utils/src/function-helpers/lib/decorators/index.ts
+++ b/packages/js-utils/src/function-helpers/lib/decorators/index.ts
@@ -1,0 +1,5 @@
+import { debounce as debounceHelper, throttle as throttleHelper } from "../../";
+import { decoratorGenerator } from "./decoratorGenerator";
+
+export const debounce = decoratorGenerator(debounceHelper);
+export const throttle = decoratorGenerator(throttleHelper);

--- a/packages/js-utils/src/function-helpers/lib/decorators/index.ts
+++ b/packages/js-utils/src/function-helpers/lib/decorators/index.ts
@@ -1,5 +1,5 @@
 import { debounce as debounceHelper, throttle as throttleHelper } from "../../";
 import { decoratorGenerator } from "./decoratorGenerator";
 
-export const debounce = decoratorGenerator(debounceHelper);
-export const throttle = decoratorGenerator(throttleHelper);
+export const debounce = decoratorGenerator(debounceHelper) as (wait?: number) => MethodDecorator;
+export const throttle = decoratorGenerator(throttleHelper) as (wait?: number) => MethodDecorator;

--- a/packages/js-utils/src/function-helpers/lib/throttle.ts
+++ b/packages/js-utils/src/function-helpers/lib/throttle.ts
@@ -1,6 +1,6 @@
 /**
  * returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.
- * call `.cancel()` on the returned function, to cancel the callback invokation.
+ * call `.cancel()` on the returned function, to cancel the callback invocation.
  *
  *
  * @example

--- a/packages/services/src/MediaQueryService.ts
+++ b/packages/services/src/MediaQueryService.ts
@@ -1,4 +1,4 @@
-import { throttle } from '@kluntje/js-utils/lib/function-helpers';
+import { throttle } from '@kluntje/js-utils/lib/function-helpers/lib/decorators';
 import { onEvent, getCurrentMQ, MQDefinition } from '@kluntje/js-utils/lib/dom-helpers';
 
 export class MediaQueryService {
@@ -25,7 +25,8 @@ export class MediaQueryService {
     return MediaQueryService.instance;
   }
 
-  handleMQChange = throttle(() => {
+  @throttle(100)
+  handleMQChange() {
     const newMQ = getCurrentMQ(MediaQueryService.mediaQuerys);
     if (newMQ === this.lastMQ) {
       return;
@@ -41,5 +42,5 @@ export class MediaQueryService {
     );
 
     this.lastMQ = newMQ;
-  }, 100);
+  }
 }

--- a/packages/services/src/MediaQueryService.ts
+++ b/packages/services/src/MediaQueryService.ts
@@ -1,4 +1,4 @@
-import { throttle } from '@kluntje/js-utils/lib/function-helpers/lib/decorators';
+import { throttle } from '@kluntje/js-utils/lib/function-helpers/decorators';
 import { onEvent, getCurrentMQ, MQDefinition } from '@kluntje/js-utils/lib/dom-helpers';
 
 export class MediaQueryService {

--- a/scripts/jsdoc2md.js
+++ b/scripts/jsdoc2md.js
@@ -1,11 +1,14 @@
 const jsdoc2md = require('jsdoc-to-markdown');
 const fs = require('fs');
 
-const renderReadme = async(templatePath) => {
-  const template = fs.readFileSync(templatePath, {encoding: "UTF-8"});
-  const renderReadme = await jsdoc2md.render({ files: './packages/js-utils/lib/**/*.js' });
-  const rederedReadme =  template.replace("{%body%}", renderReadme);
-  fs.writeFileSync("./packages/js-utils/README.md", rederedReadme, {encoding: "UTF-8"});
-}
+const renderReadme = async templatePath => {
+  const template = fs.readFileSync(templatePath, { encoding: 'UTF-8' });
+  const renderReadme = await jsdoc2md.render({
+    files: './packages/js-utils/src/**/*.ts',
+    configure: './jsdoc2md.json',
+  });
+  const rederedReadme = template.replace('{%body%}', renderReadme);
+  fs.writeFileSync('./packages/js-utils/README.md', rederedReadme, { encoding: 'UTF-8' });
+};
 
-renderReadme("./packages/js-utils/README.template.md");
+renderReadme('./packages/js-utils/README.template.md');


### PR DESCRIPTION


== Description ==
To provide easier migration to projects using lodash-decorator to @kluntjte/js-utils, the `debounce` and `throttle` helpers are porvided as class method decorators as well.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
js-utils
services