### PR TITLE
chore: generate sourcemaps in addition to compiled js

### DIFF
--- a/rollup.lerna.js
+++ b/rollup.lerna.js
@@ -6,10 +6,12 @@ export const generateRollupConfig = (pkg, inputPath) => ({
     {
       file: pkg.main,
       format: 'cjs',
+      sourcemap: true,
     },
     {
       file: pkg.module,
       format: 'es', // the preferred format
+      sourcemap: true,
     },
   ],
   external: [...Object.keys(pkg.dependencies || {})],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true /* Generates corresponding '.d.ts' file. */,
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
== Description ==
published code is minified, to provide a better readability for example when debugging, generate and export source-maps.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
all