### PR TITLE
feat(all): use `.mjs` extenstion for better ootb esm support by consumers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,8 +11,9 @@
   ],
   "license": "Apache-2.0",
   "main": "lib/component.js",
-  "module": "lib/component.module.js",
+  "module": "lib/component.mjs",
   "types": "lib/component.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/js-utils/build.js
+++ b/packages/js-utils/build.js
@@ -6,63 +6,63 @@ const bundles = {
     inputPath: './src/index.ts',
     outFiles: {
       main: './lib/index.js',
-      module: './lib/index.module.js',
+      module: './lib/index.mjs',
     },
   },
   apiHelpers: {
     inputPath: './src/api-helpers/index.ts',
     outFiles: {
       main: 'lib/api-helpers/index.js',
-      module: 'lib/api-helpers/index.module.js',
+      module: 'lib/api-helpers/index.mjs',
     },
   },
   arrayHelpers: {
     inputPath: './src/array-helpers/index.ts',
     outFiles: {
       main: 'lib/array-helpers/index.js',
-      module: 'lib/array-helpers/index.module.js',
+      module: 'lib/array-helpers/index.mjs',
     },
   },
   dateHelpers: {
     inputPath: './src/date-helpers/index.ts',
     outFiles: {
       main: 'lib/date-helpers/index.js',
-      module: 'lib/date-helpers/index.module.js',
+      module: 'lib/date-helpers/index.mjs',
     },
   },
   domHelpers: {
     inputPath: './src/dom-helpers/index.ts',
     outFiles: {
       main: 'lib/dom-helpers/index.js',
-      module: 'lib/dom-helpers/index.module.js',
+      module: 'lib/dom-helpers/index.mjs',
     },
   },
   functionHelpers: {
     inputPath: './src/function-helpers/index.ts',
     outFiles: {
       main: 'lib/function-helpers/index.js',
-      module: 'lib/function-helpers/index.module.js',
+      module: 'lib/function-helpers/index.mjs',
     },
   },
   "functionHelpers/decorators": {
     inputPath: './src/function-helpers/decorators.ts',
     outFiles: {
       main: 'lib/function-helpers/decorators/index.js',
-      module: 'lib/function-helpers/decorators/index.module.js',
+      module: 'lib/function-helpers/decorators/index.mjs',
     },
   },
   objectHelpers: {
     inputPath: './src/object-helpers/index.ts',
     outFiles: {
       main: 'lib/object-helpers/index.js',
-      module: 'lib/object-helpers/index.module.js',
+      module: 'lib/object-helpers/index.mjs',
     },
   },
   stringHelpers: {
     inputPath: './src/string-helpers/index.ts',
     outFiles: {
       main: 'lib/string-helpers/index.js',
-      module: 'lib/string-helpers/index.module.js',
+      module: 'lib/string-helpers/index.mjs',
     },
   },
 };

--- a/packages/js-utils/package.json
+++ b/packages/js-utils/package.json
@@ -11,8 +11,9 @@
   ],
   "license": "Apache-2.0",
   "main": "lib/index.js",
-  "module": "lib/index.module.js",
+  "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -9,8 +9,9 @@
   ],
   "license": "Apache-2.0",
   "main": "lib/index.js",
-  "module": "lib/index.module.js",
+  "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
it is common to use .mjs when exorting ES mosules, which for example webpack uses as one of its
default extention for file resolution, also mark modules as side effect free. these changes will
allow better tree-shakability to the kluntje

== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
