### PR TITLE
feat(js-utils): add promise wrapper for animation and transition end events

### DIFF
--- a/packages/js-utils/src/dom-helpers/index.ts
+++ b/packages/js-utils/src/dom-helpers/index.ts
@@ -17,4 +17,6 @@ export { getParent } from './lib/getParent';
 export { waitFor } from './lib/waitFor';
 export { Context } from './lib/Context';
 export { waitForEvent } from './lib/waitForEvent';
+export { waitForAnimationEnd } from './lib/waitForAnimationEnd';
+export { waitForTransitionEnd } from './lib/waitForTransitionEnd';
 export { getCurrentMQ, MQDefinition } from './lib/getCurrentMQ';

--- a/packages/js-utils/src/dom-helpers/lib/waitForAnimationEnd.ts
+++ b/packages/js-utils/src/dom-helpers/lib/waitForAnimationEnd.ts
@@ -1,0 +1,21 @@
+/**
+ * returns a promise which resolves after the animationend event
+ *
+ * @param {HTMLElement|SVGElement} el - DOM Element which has the css animation
+ * @param {string} [animationName] - keyframes' name. e.g. "slideOut"
+ * @returns {Promise}
+ */
+export function waitForAnimationEnd(el: HTMLElement, animationName?: string): Promise<AnimationEvent> {
+  return new Promise((resolve, _reject) => {
+    el.addEventListener<'animationend'>('animationend', function callBack(e: AnimationEvent) {
+      // if animationName is given then ignore animation for other keyframes
+      if (animationName && e.animationName !== animationName) {
+        return;
+      }
+      // unbind the event listener
+      el.removeEventListener('animationend', callBack);
+      // resolve promise with the transitionend event as its argument
+      resolve(e);
+    });
+  });
+}

--- a/packages/js-utils/src/dom-helpers/lib/waitForAnimationEnd.ts
+++ b/packages/js-utils/src/dom-helpers/lib/waitForAnimationEnd.ts
@@ -1,6 +1,17 @@
 /**
  * returns a promise which resolves after the animationend event
  *
+ * @example
+ * ```
+ *   el.classList.add("hide");
+ *   await waitForAnimationEnd(el, "fade-out");
+ *   el.parentElement.removeChild(el);
+ *   // css:
+ *   // .hide {
+ *   //   animation: fade-out 0.5s forwards;
+ *   // }
+ * ```
+ *
  * @param {HTMLElement|SVGElement} el - DOM Element which has the css animation
  * @param {string} [animationName] - keyframes' name. e.g. "slideOut"
  * @returns {Promise}
@@ -8,6 +19,8 @@
 export function waitForAnimationEnd(el: HTMLElement, animationName?: string): Promise<AnimationEvent> {
   return new Promise((resolve, _reject) => {
     el.addEventListener<'animationend'>('animationend', function callBack(e: AnimationEvent) {
+      // ignore child animations
+      if (e.target !== el) return;
       // if animationName is given then ignore animation for other keyframes
       if (animationName && e.animationName !== animationName) {
         return;

--- a/packages/js-utils/src/dom-helpers/lib/waitForTransitionEnd.ts
+++ b/packages/js-utils/src/dom-helpers/lib/waitForTransitionEnd.ts
@@ -1,0 +1,22 @@
+/**
+ * returns a promise which resolves after the `transitionend` event
+ *
+ * @param {HTMLElement|SVGElement} el - DOM Element which has the css transition
+ * @param {string} [propertyName] - transition's propertyName. e.g. "width"
+ * @returns {Promise}
+ * @async
+ */
+export function waitForTransitionEnd(el: HTMLElement, propertyName?: string): Promise<TransitionEvent> {
+  return new Promise((resolve, _reject) => {
+    el.addEventListener<'transitionend'>('transitionend', function callBack(e: TransitionEvent) {
+      // if propertyName is given then ignore trasnition on other properties
+      if (propertyName && e.propertyName !== propertyName) {
+        return;
+      }
+      // unbind the event listener
+      el.removeEventListener('transitionend', callBack);
+      // resolve promise with the transitionend event as its argument
+      resolve(e);
+    });
+  });
+}

--- a/packages/js-utils/src/dom-helpers/lib/waitForTransitionEnd.ts
+++ b/packages/js-utils/src/dom-helpers/lib/waitForTransitionEnd.ts
@@ -1,6 +1,15 @@
 /**
  * returns a promise which resolves after the `transitionend` event
  *
+ * @example
+ * ```
+ *   menu.classList.add("open");
+ *   await waitForTransitionEnd(menu, "transform");
+ *   input.classList.add("visible");
+ *   await waitForTransitionEnd(input, "opacity");
+ *   input.focus();
+ * ```
+ *
  * @param {HTMLElement|SVGElement} el - DOM Element which has the css transition
  * @param {string} [propertyName] - transition's propertyName. e.g. "width"
  * @returns {Promise}
@@ -9,6 +18,8 @@
 export function waitForTransitionEnd(el: HTMLElement, propertyName?: string): Promise<TransitionEvent> {
   return new Promise((resolve, _reject) => {
     el.addEventListener<'transitionend'>('transitionend', function callBack(e: TransitionEvent) {
+      // ignore child transitions
+      if (e.target !== el) return;
       // if propertyName is given then ignore trasnition on other properties
       if (propertyName && e.propertyName !== propertyName) {
         return;


### PR DESCRIPTION
== Description ==
handy helper when js has to run stuff after css animations/transition

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
js-utils