### PR TITLE
fix(core): accessible ui definitions to make preservable after updateUI

### DIFF
--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -32,7 +32,7 @@ export interface ComponentArgs {
 }
 
 export class Component extends HTMLElement {
-  private uiDefinitions: ComponentUiElementDefinitions = {};
+  protected uiDefinitions: ComponentUiElementDefinitions = {};
   protected ui: ComponentUiElements = {};
   private events: Array<ComponentEvent<this>> = [];
   private useShadowDOM: boolean;


### PR DESCRIPTION
== Description ==

UI definitions (old fashioned, no decorators) need to make preservable for components with inheritance

Scenario: 
Core Component -> Base Component -> Child Component
After `childComponent.updateUI()` -> `childComponent.ui` will contain uiDefinitions of base component only

== Closes issue(s) ==


== Changes ==
Made core component "uiDefinitions" accessible for sub classes
Could be preserved on base components constructor along with other props now

```
Object.assign(this.ui, ui);
Object.assign(this.uiDefinitions, ui);
Object.assign(this.initialStates, initialStates);
Object.assign(this.reactions, reactions);

this.mergeEvents();
```

== Affected Packages ==
