### PR TITLE
fix(services): fixed FF issue in URLSearchParamService with empty hashes

### DIFF
--- a/packages/services/src/URLSearchParamsService.ts
+++ b/packages/services/src/URLSearchParamsService.ts
@@ -38,7 +38,7 @@ export class URLSearchParamsService {
     const hashCache = window.location.hash;
     const newUrl = curQueryString !== '' ? `${curUrl}?${curQueryString}` : curUrl;
     window.history.replaceState({ path: newUrl }, '', newUrl);
-    window.location.hash = hashCache;
+    if (hashCache !== '') window.location.hash = hashCache;
   }
 }
 


### PR DESCRIPTION
== Description ==
fixed FF issue in URLSearchParamService, where empty cached hashes were not ignored. this let to an
unintentional scroll-top


== Closes issue(s) ==
-

== Changes ==


== Affected Packages ==
@kluntje/services
