### PR TITLE
docs(js-utils): add name of each js-utils submodule to docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,7 +56,7 @@ We strongly suggest to document your code at least with proper [JSDoc](https://g
 The following script will parse your source for `JSDoc` annotations and automatically add your changes to the documentation.
 
 ```bash
-$ node ./scripts/jsdoc2md.js
+$ npm run doc
 ```
 
 Once everything is done conclude your development task with a commit

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "publish": "lerna run build && lerna publish --conventional-commits -m \"chore(root): Publish packages\"",
     "publish:canary": "lerna run build && lerna publish --canary --force-publish=* -m \"chore(root): Publish canary version\"",
     "build": "lerna run build",
+    "doc": "node ./scripts/jsdoc2md/jsdoc2md.js",
     "test": "lerna run test",
     "jest": "jest --watch",
     "bootstrap": "lerna bootstrap",

--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -14,11 +14,29 @@
 npm install @kuntje/js-utils
 ```
 
+## Usage
+
+```js
+import { inViewport } from '@kluntje/js-utils/lib/dom-helpers';
+const inView = inViewport(document.querySelector("#teaser"));
+
+// You can also import from top level. But this is not suitable for three shaking!
+import { domHelpers } from "@kluntje/js-utils";
+const inView = domHelpers.inViewport(document.querySelector("#teaser"));
+```
+
 ## Functions
+
+### api-helpers
 
 <dl>
 <dt><a href="#fetchJSON">fetchJSON(url, [options])</a> ⇒ <code>Promise.&lt;T&gt;</code></dt>
 <dd><p>Calls API and returns JSON as Promise</p></dd>
+</dl>
+
+### array-helpers
+
+<dl>
 <dt><a href="#hasElement">hasElement(array, element)</a> ⇒ <code>boolean</code></dt>
 <dd><p>checks, if element is in given array</p></dd>
 <dt><a href="#isFilledArray">isFilledArray(array)</a> ⇒ <code>boolean</code></dt>
@@ -29,6 +47,11 @@ npm install @kuntje/js-utils
 <dd><p>pushes new Element to given array, if its not already in it</p></dd>
 <dt><a href="#removeItem">removeItem(array, itemToRemove)</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
 <dd><p>removes specific Item from array and return new array</p></dd>
+</dl>
+
+### date-helpers
+
+<dl>
 <dt><a href="#addDays">addDays(date, daysToAdd, [zeroHours])</a> ⇒ <code>Date</code></dt>
 <dd><p>Adds given amount of days to given date</p></dd>
 <dt><a href="#addLeadingZero">addLeadingZero(inNumber)</a> ⇒ <code>string</code></dt>
@@ -41,6 +64,11 @@ Some browsers (e.g. Safari) need the GMT offset part to be in format &quot;+00:0
 This helper makes sure that any present GMT offset follows that format and can safely be parsed:
 Date.parse(&quot;2020-01-01T12:13:14.000+0200&quot;) // throws error in Safari
 Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p></dd>
+</dl>
+
+### dom-helpers
+
+<dl>
 <dt><a href="#addClass">addClass(elements, ...classNames)</a></dt>
 <dd><p>adds given classes to one or multiple elements</p></dd>
 <dt><a href="#find">find(parent, selector)</a> ⇒ <code>Element</code> | <code>null</code></dt>
@@ -79,6 +107,11 @@ Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p></dd>
 <dd><p>resolves Promise after given timeout</p></dd>
 <dt><a href="#waitForEvent">waitForEvent(target, eventName, timeout)</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
 <dd><p>waits for given event for a (optional) max-timeout</p></dd>
+</dl>
+
+### function-helpers
+
+<dl>
 <dt><a href="#debounce">debounce(callback, [wait])</a> ⇒ <code>function</code></dt>
 <dd><p>returns a debounced function which when called multiple of times each time it waits the waiting duration
 and if the method was not called during this time, the last call will be passed to the callback.</p></dd>
@@ -88,6 +121,11 @@ helper function should have this signature: <code>(Function, ...args: any[]) =&g
 <dt><a href="#throttle">throttle(callback, [wait])</a> ⇒ <code>function</code></dt>
 <dd><p>returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.
 call <code>.cancel()</code> on the returned function, to cancel the callback invocation.</p></dd>
+</dl>
+
+### object-helpers
+
+<dl>
 <dt><del><a href="#getValue">getValue(obj, path)</a> ⇒ <code>*</code></del></dt>
 <dd><p>returns nested value without throwing an error if the parent doesn't exist</p></dd>
 <dt><a href="#isEqual">isEqual(arg1, arg2)</a> ⇒ <code>boolean</code></dt>
@@ -100,6 +138,11 @@ call <code>.cancel()</code> on the returned function, to cancel the callback inv
 <dd><p>returns the argument wrapped in an array if it isn't array itself</p></dd>
 <dt><a href="#toString">toString(arg)</a> ⇒ <code>string</code></dt>
 <dd><p>returns stringified value for the given argument</p></dd>
+</dl>
+
+### string-helpers
+
+<dl>
 <dt><a href="#getCleanString">getCleanString(inputString)</a> ⇒ <code>string</code></dt>
 <dd><p>removes all multi Whitespaces and Newlines in given string</p></dd>
 <dt><a href="#getWordCount">getWordCount(text)</a> ⇒ <code>number</code></dt>
@@ -118,12 +161,13 @@ call <code>.cancel()</code> on the returned function, to cancel the callback inv
 
 ## Typedefs
 
+### dom-helpers
+
 <dl>
 <dt><a href="#callback">callback</a> : <code>function</code></dt>
 <dd><p>iterates over all nodes in a node list
 (necessary because IE11 doesn't support .forEach  * for NodeLists)</p></dd>
 </dl>
-
 <a name="fetchJSON"></a>
 
 ## fetchJSON(url, [options]) ⇒ <code>Promise.&lt;T&gt;</code>

--- a/packages/js-utils/README.template.md
+++ b/packages/js-utils/README.template.md
@@ -14,6 +14,16 @@
 npm install @kuntje/js-utils
 ```
 
+## Usage
+
+```js
+import { inViewport } from '@kluntje/js-utils/lib/dom-helpers';
+const inView = inViewport(document.querySelector("#teaser"));
+
+// You can also import from top level. But this is not suitable for three shaking!
+import { domHelpers } from "@kluntje/js-utils";
+const inView = domHelpers.inViewport(document.querySelector("#teaser"));
+```
 {%body%}
 
 ## Author

--- a/scripts/jsdoc2md/helpers/groupStart.js
+++ b/scripts/jsdoc2md/helpers/groupStart.js
@@ -1,0 +1,17 @@
+const path = require("path");
+let lastGroupName = "";
+
+// helper to find the first entry for each js-utils submodule
+exports.groupStart = function groupStart(options) {
+  // use always posix paths
+  const filePath = this.meta.path.split(path.sep).join(path.posix.sep);
+  // first directory name after js-utils/src
+  const groupName = filePath.split("packages/js-utils/src/")[1].split("/")[0];
+
+  if (groupName !== lastGroupName) {
+    lastGroupName = groupName;
+
+    return options.fn(groupName);
+  }
+  return options.inverse(this);;
+}

--- a/scripts/jsdoc2md/jsdoc2md.js
+++ b/scripts/jsdoc2md/jsdoc2md.js
@@ -6,9 +6,11 @@ const renderReadme = async templatePath => {
   const renderReadme = await jsdoc2md.render({
     files: './packages/js-utils/src/**/*.ts',
     configure: './jsdoc2md.json',
+    helper: ["./scripts/jsdoc2md/helpers/groupStart.js"],
+    partial: ["./scripts/jsdoc2md/partials/global-index-dl.hbs"],
   });
-  const rederedReadme = template.replace('{%body%}', renderReadme);
-  fs.writeFileSync('./packages/js-utils/README.md', rederedReadme, { encoding: 'UTF-8' });
+  const renderedReadme = template.replace('{%body%}', renderReadme);
+  fs.writeFileSync('./packages/js-utils/README.md', renderedReadme, { encoding: 'UTF-8' });
 };
 
 renderReadme('./packages/js-utils/README.template.md');

--- a/scripts/jsdoc2md/partials/global-index-dl.hbs
+++ b/scripts/jsdoc2md/partials/global-index-dl.hbs
@@ -1,0 +1,17 @@
+{{#globals kind=kind}}
+{{#if @first}}
+
+{{>heading-indent}}{{../title}}{{/if}}
+{{~#groupStart~}}
+{{~#unless @first}}</dl>{{/unless}}
+
+### {{this}}
+
+<dl>
+{{/groupStart}}
+<dt>{{>sig-link-html}}</dt>
+<dd>{{{md (inlineLinks description)}}}</dd>
+{{~#if @last}}
+
+</dl>{{/if}}
+{{/globals~}}


### PR DESCRIPTION
this allows user to know which module should be imported to use the the desired utility function.

== Description ==
The generated README.md for js-utils will have the name of the sub module (e.g. api-helpers) as the group headline before its util functions

== Closes issue(s) ==


== Changes ==
Readme generation for js-utils

== Affected Packages ==
js-utils 