### PR TITLE
feat(js-utils|core): add support for event options to onEvent and ctor`s events and @uiEvents

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -195,9 +195,10 @@ constructor() {
         handler: "onFormSubmit",
       },
       {
-        event: "focusin",
-        target: "inputs",
-        handler: "handleFocusChange",
+        event: "focusout",
+        target: "input",
+        handler: "enableInvalidStyling",
+        options: { once: true }
       },
     ],
     // ...

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -252,7 +252,7 @@ export class Component extends HTMLElement {
       if (typeof this[event.handler] === 'function') {
         const targets = this.getEventTargets(event.target);
         // @ts-ignore
-        onEvent(targets, event.event, this[event.handler], this);
+        onEvent(targets, event.event, this[event.handler], this, event.options);
       }
     });
   }
@@ -265,7 +265,7 @@ export class Component extends HTMLElement {
       if (typeof this[event.handler] === 'function') {
         const targets = this.getEventTargets(event.target);
         // @ts-ignore
-        removeEvent(targets, event.event, this[event.handler], this);
+        removeEvent(targets, event.event, this[event.handler], this, event.options);
       }
     });
   }
@@ -288,9 +288,9 @@ export class Component extends HTMLElement {
       if (typeof this[event.handler] === 'function') {
         const targets = this.getEventTargets(event.target);
         // @ts-ignore
-        removeEvent(targets, event.event, this[event.handler], this);
+        removeEvent(targets, event.event, this[event.handler], this, event.options);
         // @ts-ignore
-        onEvent(targets, event.event, this[event.handler], this);
+        onEvent(targets, event.event, this[event.handler], this, event.options);
       }
     });
   }
@@ -308,12 +308,12 @@ export class Component extends HTMLElement {
       if (decoratorUiDef.selector === 'window') {
         decoratorUiDef.events.forEach((event) => {
           // @ts-ignore
-          onEvent(window, event.eventName, this[event.handler], this);
+          onEvent(window, event.eventName, this[event.handler], this, event.options);
         });
       } else if (decoratorUiDef.selector === 'this') {
         decoratorUiDef.events.forEach((event) => {
           // @ts-ignore
-          onEvent(this, event.eventName, this[event.handler], this);
+          onEvent(this, event.eventName, this[event.handler], this, event.options);
         });
       } else {
         const curEl = decoratorUiDef.justOne
@@ -323,7 +323,7 @@ export class Component extends HTMLElement {
         this[property] = curEl;
         decoratorUiDef.events.forEach((event) => {
           // @ts-ignore
-          onEvent(this[property], event.eventName, this[event.handler], this);
+          onEvent(this[property], event.eventName, this[event.handler], this, event.options);
         });
       }
     });
@@ -338,19 +338,19 @@ export class Component extends HTMLElement {
       if (decoratorUiDef.selector === 'window') {
         decoratorUiDef.events.forEach((event) => {
           // @ts-ignore
-          removeEvent(window, event.eventName, this[event.handler], this);
+          removeEvent(window, event.eventName, this[event.handler], this, event.options);
         });
       } else if (decoratorUiDef.selector === 'this') {
         decoratorUiDef.events.forEach((event) => {
           // @ts-ignore
-          removeEvent(this, event.eventName, this[event.handler], this);
+          removeEvent(this, event.eventName, this[event.handler], this, event.options);
         });
       } else {
         const curEl = this[property];
         if (curEl !== null && curEl !== undefined) {
           decoratorUiDef.events.forEach((event) => {
             // @ts-ignore
-            removeEvent(this[property], event.eventName, this[event.handler], this);
+            removeEvent(this[property], event.eventName, this[event.handler], this, event.options);
           });
         }
         // @ts-ignore

--- a/packages/core/src/component.types.ts
+++ b/packages/core/src/component.types.ts
@@ -7,6 +7,7 @@ export interface ComponentEvent<T = any> {
   event: string;
   target: string;
   handler: keyof T;
+  options?: AddEventListenerOptions;
 }
 
 export type ComponentStates = Record<string, any>;

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -11,6 +11,7 @@ export type { PropDefinition, PropCastTypes } from './prop';
 type DecoratorEventDefinition<T> = {
   handler: keyof T;
   eventName: string;
+  options?: AddEventListenerOptions;
 };
 
 export type DecoratorUiDefinition<T> = {
@@ -47,7 +48,11 @@ export function uiElements(selector: string) {
   };
 }
 
-export function uiEvent<T>(elementName: keyof T | 'window' | 'this', eventName: string) {
+export function uiEvent<T>(
+  elementName: keyof T | 'window' | 'this',
+  eventName: string,
+  options?: AddEventListenerOptions,
+) {
   return function decorator(component: any, handlerName: string) {
     if (component.decoratedUiEls === undefined) component.decoratedUiEls = new Map();
 
@@ -57,12 +62,13 @@ export function uiEvent<T>(elementName: keyof T | 'window' | 'this', eventName: 
       component.decoratedUiEls.set(elementName.toString(), {
         selector: elementName,
         justOne: true,
-        events: new Set([{ eventName, handler: handlerName }]),
+        events: new Set([{ eventName, handler: handlerName, options }]),
       });
     } else {
       curUiElement.events.add({
         eventName,
         handler: handlerName,
+        options,
       });
       component.decoratedUiEls.set(elementName, curUiElement);
     }

--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -65,13 +65,13 @@ Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p></dd>
 <dd><p>checks, whether an element is in the viewport</p></dd>
 <dt><a href="#isNodeList">isNodeList(target)</a> ⇒ <code>boolean</code></dt>
 <dd><p>checks, if target is NodeList</p></dd>
-<dt><a href="#onEvent">onEvent(target, events, handler, context)</a></dt>
+<dt><a href="#onEvent">onEvent(target, events, handler, context, [options])</a></dt>
 <dd><p>adds event with given parameters</p></dd>
 <dt><a href="#removeChildren">removeChildren(parent, selector)</a></dt>
 <dd><p>removes all children of a specific parent matching the given selector</p></dd>
 <dt><a href="#removeClass">removeClass(elements, ...classNames)</a></dt>
 <dd><p>removes given class from element</p></dd>
-<dt><a href="#removeEvent">removeEvent(target, events, handler, context)</a></dt>
+<dt><a href="#removeEvent">removeEvent(target, events, handler, context, [options])</a></dt>
 <dd><p>removes event with given parameters</p></dd>
 <dt><a href="#toggleClass">toggleClass(elements, className, add)</a></dt>
 <dd><p>toggles given class on given element</p></dd>
@@ -555,7 +555,7 @@ if (inViewport(image)) image.setAttribute('src', image.dataset('src'));
 
 <a name="onEvent"></a>
 
-## onEvent(target, events, handler, context)
+## onEvent(target, events, handler, context, [options])
 <p>adds event with given parameters</p>
 
 **Kind**: global function  
@@ -566,6 +566,7 @@ if (inViewport(image)) image.setAttribute('src', image.dataset('src'));
 | events | <code>string</code> \| <code>Array.&lt;string&gt;</code> | 
 | handler | <code>function</code> | 
 | context | <code>Context</code> | 
+| [options] | <code>AddEventListenerOptions</code> | 
 
 **Example**  
 ```js
@@ -613,7 +614,7 @@ removeClass(inputs, 'active');
 ```
 <a name="removeEvent"></a>
 
-## removeEvent(target, events, handler, context)
+## removeEvent(target, events, handler, context, [options])
 <p>removes event with given parameters</p>
 
 **Kind**: global function  
@@ -624,6 +625,7 @@ removeClass(inputs, 'active');
 | events | <code>string</code> \| <code>Array.&lt;string&gt;</code> | 
 | handler | <code>function</code> | 
 | context | <code>Context</code> | 
+| [options] | <code>AddEventListenerOptions</code> | 
 
 **Example**  
 ```js

--- a/packages/js-utils/src/dom-helpers/lib/onEvent.ts
+++ b/packages/js-utils/src/dom-helpers/lib/onEvent.ts
@@ -11,6 +11,7 @@ export type EventHandler<T> = (e: T) => void;
  * @param {string | Array<string>} events
  * @param {Function} handler
  * @param {Context} context
+ * @param {AddEventListenerOptions} [options]
  * @example
  * const buttons = findAll(document, 'button);
  * onEvent(buttons, 'click', () => console.log('button clicked'), this);
@@ -20,6 +21,7 @@ export const onEvent = <T extends Event = Event>(
   events: string | Array<string>,
   handler: EventHandler<T>,
   context: Context,
+  options?: AddEventListenerOptions,
 ) => {
   if (target === undefined
     || target === null
@@ -30,7 +32,7 @@ export const onEvent = <T extends Event = Event>(
 
   if (isIterable<HTMLElement>(target) && !(target instanceof HTMLElement)) {
     for (const element of target) {
-      onEvent(element, events, handler, context);
+      onEvent(element, events, handler, context, options);
     }
     return;
   }
@@ -44,11 +46,12 @@ export const onEvent = <T extends Event = Event>(
   }
 
   eventList.forEach(event => {
+    // assuming there is no use-case to add multiple eventListeners with same arguments were only the eventListenerOptions is different
     const key = getKey(target, event, handler, context);
     if (!context.eventBindingMap[key]) { // can't add two listeners with exact same arguments
       const newFunc = handler.bind(context) as EventListener;
       context.eventBindingMap[key] = newFunc;
-      return target.addEventListener(event.trim(), newFunc);
+      return target.addEventListener(event.trim(), newFunc, options);
     }
   });
 };

--- a/packages/js-utils/src/dom-helpers/lib/removeEvent.ts
+++ b/packages/js-utils/src/dom-helpers/lib/removeEvent.ts
@@ -8,6 +8,7 @@ import { Context } from './Context';
  * @param {string | Array<string>} events
  * @param {Function} handler
  * @param {Context} context
+ * @param {AddEventListenerOptions} [options]
  * @example
  * const buttons = findAll(document, 'button);
  * removeEvent(buttons, 'click', () => console.log('button clicked'), this);
@@ -17,6 +18,7 @@ export const removeEvent = <T extends Event = Event>(
   events: string | Array<string>,
   handler: EventHandler<T>,
   context: Context,
+  options?: AddEventListenerOptions,
 ) => {
   if (target === undefined
     || target === null
@@ -27,7 +29,7 @@ export const removeEvent = <T extends Event = Event>(
 
   if (isIterable<HTMLElement>(target) && !(target instanceof HTMLElement)) {
     for (const element of target) {
-      removeEvent(element, events, handler, context);
+      removeEvent(element, events, handler, context, options);
     }
     return;
   }
@@ -45,7 +47,7 @@ export const removeEvent = <T extends Event = Event>(
     const newFunc = context.eventBindingMap[key];
     if (newFunc) { // can't add two listeners with exact same arguments
       delete context.eventBindingMap[key];
-      target.removeEventListener(event, newFunc);
+      target.removeEventListener(event, newFunc, options);
     }
   });
 };

--- a/packages/js-utils/src/dom-helpers/tests/onEvent.test.ts
+++ b/packages/js-utils/src/dom-helpers/tests/onEvent.test.ts
@@ -63,6 +63,14 @@ describe('onEvent tests:', () => {
         expect(mockContext.mockHandler).toBeCalled();
       });
 
+      test('should add eventListener with options to target', () => {
+        onEvent(mockTarget, 'click', mockContext.mockHandler, mockContext, { once: true });
+        mockTarget.dispatchEvent(new Event('click'));
+        // second click shouldn't trigger callback when `once` option is used
+        mockTarget.dispatchEvent(new Event('click'));
+        expect(mockContext.mockHandler).toHaveBeenCalledTimes(1);
+      });
+
       test('should add listeners for all events in space separeted string', () => {
         onEvent(mockTarget, 'click touchstart touchend', mockContext.mockHandler, mockContext);
         expect(mockTarget.addEventListener).toBeCalledTimes(3);

--- a/packages/js-utils/src/dom-helpers/tests/removeEvent.test.ts
+++ b/packages/js-utils/src/dom-helpers/tests/removeEvent.test.ts
@@ -64,6 +64,13 @@ describe('removeEvent tests:', () => {
         expect(mockContext.mockHandler).not.toBeCalled();
       });
 
+      test('should remove eventListener with option from target', () => {
+        onEvent(mockTarget, 'click', mockContext.mockHandler, mockContext, { once: true });
+        removeEvent(mockTarget, 'click', mockContext.mockHandler, mockContext, { once: true });
+        mockTarget.dispatchEvent(new Event('click'));
+        expect(mockContext.mockHandler).not.toBeCalled();
+      });
+
       test('should remove listeners of all events in space separeted string', () => {
         onEvent(mockTarget, 'click touchstart touchend', mockContext.mockHandler, mockContext);
         removeEvent(mockTarget, 'click touchstart touchend', mockContext.mockHandler, mockContext);


### PR DESCRIPTION
== Description ==
Event [options](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) can be passed to `onEvent` or Component's `events`.
This allows e.g. setting an eventListenre for only one interaction declaratively without the need to manually remove it. Or setting it as `passive`, what lighthouse audit used to nag in some cases about.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
core, js-utils