### PR TITLE
fix(services): dispatch in/out vp event non-bubbling

### DIFF
--- a/packages/services/src/ViewportObserver.ts
+++ b/packages/services/src/ViewportObserver.ts
@@ -23,9 +23,9 @@ export class ViewportObserver {
       const target = observedEl.target;
 
       if (observedEl.isIntersecting) {
-        target.dispatchEvent(new CustomEvent(IN_VP_EVENT));
+        target.dispatchEvent(new CustomEvent(IN_VP_EVENT, { bubbles: false }));
       } else {
-        target.dispatchEvent(new CustomEvent(OUT_VP_EVENT));
+        target.dispatchEvent(new CustomEvent(OUT_VP_EVENT, { bubbles: false }));
       }
     });
   }

--- a/packages/services/src/tests/ViewportObserver.test.ts
+++ b/packages/services/src/tests/ViewportObserver.test.ts
@@ -84,14 +84,14 @@ describe('ViewportObsever tests:', () => {
     test('should dispatch kl-in-vp event on all intersecting element', () => {
       expect(mockObservedEl1.dispatchEvent).toBeCalled();
       expect(mockObservedEl3.dispatchEvent).toBeCalled();
-      expect(window.CustomEvent).nthCalledWith(1, 'kl-in-vp');
-      expect(window.CustomEvent).nthCalledWith(3, 'kl-in-vp');
+      expect(window.CustomEvent).nthCalledWith(1, 'kl-in-vp', { bubbles: false });
+      expect(window.CustomEvent).nthCalledWith(3, 'kl-in-vp', { bubbles: false });
     });
 
     test('should dispatch kl-out-vp event on all non-intersecting element', () => {
       expect(mockObservedEl2.dispatchEvent).toBeCalled();
       expect(mockObservedEl4.dispatchEvent).toBeCalled();
-      expect(window.CustomEvent).nthCalledWith(4, 'kl-out-vp');
+      expect(window.CustomEvent).nthCalledWith(4, 'kl-out-vp', { bubbles: false });
     });
   });
 });


### PR DESCRIPTION
== Description ==

prevent vp-event listener on parent element also being called when a child element comes in / goes out of
viewport


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
services