### PR TITLE
fix(js-utils): use the same callback argument as the platforms NodeList#forEach uses

### DIFF
--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -47,7 +47,7 @@ Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p></dd>
 <dd><p>returns the first child of a specific parent matching the given selector</p></dd>
 <dt><a href="#findAll">findAll(parent, selector)</a> ⇒ <code>Array.&lt;Element&gt;</code></dt>
 <dd><p>returns all children of a specific parent matching the given selector</p></dd>
-<dt><a href="#callback">callback(node, index)</a> ⇒</dt>
+<dt><a href="#callback">callback(node, index, nodeList)</a></dt>
 <dd></dd>
 <dt><a href="#getCurrentMQ">getCurrentMQ(mediaQueries)</a> ⇒ <code>string</code></dt>
 <dd><p>returns current mediaQuery-name. e.g. &quot;MQ2&quot;</p></dd>
@@ -414,14 +414,14 @@ const inputs = findAll(document, 'input');
 ```
 <a name="callback"></a>
 
-## callback(node, index) ⇒
+## callback(node, index, nodeList)
 **Kind**: global function  
-**Returns**: <p>any</p>  
 
 | Param | Type |
 | --- | --- |
 | node | <code>Node</code> | 
 | index | <code>Number</code> | 
+| nodeList | <code>NodeListOf.&lt;T&gt;</code> | 
 
 <a name="getCurrentMQ"></a>
 
@@ -990,10 +990,10 @@ toKebabCase("keyValuePair") === "key-value-pair"
 
 **Kind**: global typedef  
 
-| Param | Type |
-| --- | --- |
-| nodeList | <code>NodeListOf.&lt;T&gt;</code> | 
-| [context] | <code>Context</code> | 
+| Param | Type | Default |
+| --- | --- | --- |
+| nodeList | <code>NodeListOf.&lt;T&gt;</code> |  | 
+| [context] | <code>any</code> | <code>window</code> | 
 
 **Example**  
 ```js

--- a/packages/js-utils/src/dom-helpers/lib/forEachNode.ts
+++ b/packages/js-utils/src/dom-helpers/lib/forEachNode.ts
@@ -1,11 +1,9 @@
-import { Context } from "./Context";
-
 /**
  * iterates over all nodes in a node list
  * (necessary because IE11 doesn't support .forEach  * for NodeLists)
  * @param {NodeListOf<T>} nodeList
  * @callback callback
- * @param {Context} [context]
+ * @param {any} [context=window]
  * @example
  * const buttons = document.querySelectorAll('button');
  * forEachNode(buttons, (button, idx) => addClass(button, `my-button--${idx}`))
@@ -15,19 +13,15 @@ import { Context } from "./Context";
  * @function callback
  * @param {Node} node
  * @param {Number} index
- * @return any
+ * @param {NodeListOf<T>} nodeList
  */
 
 export const forEachNode = <T extends Element = Element>(
   nodeList: NodeListOf<T>,
-  callback: (node: T, index: number) => any,
-  context?: Context
+  callback: (node: T, index: number, nodeList: NodeListOf<T>) => any,
+  context: any = window,
 ): void => {
   for (let i = 0; i < nodeList.length; i++) {
-    if(!context) {
-      callback.call(null, nodeList[i], i);
-    } else {
-      callback.call(context, nodeList[i], i);
-    }
+    callback.call(context, nodeList[i], i, nodeList);
   }
 };


### PR DESCRIPTION


== Description ==

Actually the whole `forEachNode` helper isn't used anymore and could probably be removed or at least be replaced by a pollyfill import for example from core-js for DOM collections.

(On the same note, does kluntje still need to support Internet Explorer?)

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
js-utils