### PR TITLE
feat(js-utils): extend suported types in deep clone

### DIFF
--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -636,7 +636,7 @@ export class Component extends HTMLElement {
    */
   public setState(change: object, { merge = true, silent = false } = {}) {
     const oldState = this.state;
-    this._state = Object.assign({}, merge ? oldState : {}, change);
+    this._state = naiveClone(Object.assign({}, merge ? oldState : {}, change));
 
     if (silent || isEqual(oldState, this._state)) {
       return this;

--- a/packages/js-utils/README.md
+++ b/packages/js-utils/README.md
@@ -77,8 +77,12 @@ Date.parse(&quot;2020-01-01T12:13:14.000+02:00&quot;) // succes</p></dd>
 <dd><p>toggles given class on given element</p></dd>
 <dt><a href="#waitFor">waitFor(timeout)</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
 <dd><p>resolves Promise after given timeout</p></dd>
+<dt><a href="#waitForAnimationEnd">waitForAnimationEnd(el, [animationName])</a> ⇒ <code>Promise</code></dt>
+<dd><p>returns a promise which resolves after the animationend event</p></dd>
 <dt><a href="#waitForEvent">waitForEvent(target, eventName, timeout)</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
 <dd><p>waits for given event for a (optional) max-timeout</p></dd>
+<dt><a href="#waitForTransitionEnd">waitForTransitionEnd(el, [propertyName])</a> ⇒ <code>Promise</code></dt>
+<dd><p>returns a promise which resolves after the <code>transitionend</code> event</p></dd>
 <dt><a href="#debounce">debounce(callback, [wait])</a> ⇒ <code>function</code></dt>
 <dd><p>returns a debounced function which when called multiple of times each time it waits the waiting duration
 and if the method was not called during this time, the last call will be passed to the callback.</p></dd>
@@ -88,14 +92,14 @@ helper function should have this signature: <code>(Function, ...args: any[]) =&g
 <dt><a href="#throttle">throttle(callback, [wait])</a> ⇒ <code>function</code></dt>
 <dd><p>returns a throttled function which when called, waits the given period of time before passing the last call during this time to the provided callback.
 call <code>.cancel()</code> on the returned function, to cancel the callback invocation.</p></dd>
-<dt><del><a href="#getValue">getValue(obj, path)</a> ⇒ <code>*</code></del></dt>
+<dt><a href="#getValue">getValue(obj, path)</a> ⇒ <code>*</code></dt>
 <dd><p>returns nested value without throwing an error if the parent doesn't exist</p></dd>
 <dt><a href="#isEqual">isEqual(arg1, arg2)</a> ⇒ <code>boolean</code></dt>
 <dd><p>compare two arguments, for object their toString values are compared</p></dd>
 <dt><a href="#isFilledObject">isFilledObject(obj)</a> ⇒ <code>boolean</code></dt>
 <dd><p>checks if provided argument is an object which has at least one entry in it.</p></dd>
-<dt><a href="#naiveClone">naiveClone(arg)</a> ⇒ <code>Nullable.&lt;T&gt;</code> | <code>Array.&lt;T&gt;</code></dt>
-<dd><p>returns a deep link of the provided argument</p></dd>
+<dt><a href="#naiveClone">naiveClone(arg)</a> ⇒ <code>T</code></dt>
+<dd><p>returns a deep clone of the provided argument. supports any primitive types, arrays, sets, maps, dates which can also be deeply nested in an object.</p></dd>
 <dt><a href="#toArray">toArray(arg)</a> ⇒ <code>Array.&lt;T&gt;</code></dt>
 <dd><p>returns the argument wrapped in an array if it isn't array itself</p></dd>
 <dt><a href="#toString">toString(arg)</a> ⇒ <code>string</code></dt>
@@ -670,6 +674,28 @@ addClass(button, 'animate');
 await waitFor(300);
 removeClass(button, 'animate');
 ```
+<a name="waitForAnimationEnd"></a>
+
+## waitForAnimationEnd(el, [animationName]) ⇒ <code>Promise</code>
+<p>returns a promise which resolves after the animationend event</p>
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| el | <code>HTMLElement</code> \| <code>SVGElement</code> | <p>DOM Element which has the css animation</p> |
+| [animationName] | <code>string</code> | <p>keyframes' name. e.g. &quot;slideOut&quot;</p> |
+
+**Example**  
+```
+  el.classList.add("hide");
+  await waitForAnimationEnd(el, "fade-out");
+  el.parentElement.removeChild(el);
+  // css:
+  // .hide {
+  //   animation: fade-out 0.5s forwards;
+  // }
+```
 <a name="waitForEvent"></a>
 
 ## waitForEvent(target, eventName, timeout) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -693,6 +719,26 @@ waitForEvent(button, 'transitionend', 500).then(() => removeClass(button, 'anima
 addClass(button, 'animate');
 await waitForEvent(button, 'transitionend', 500);
 removeClass(button, 'animate');
+```
+<a name="waitForTransitionEnd"></a>
+
+## waitForTransitionEnd(el, [propertyName]) ⇒ <code>Promise</code>
+<p>returns a promise which resolves after the <code>transitionend</code> event</p>
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| el | <code>HTMLElement</code> \| <code>SVGElement</code> | <p>DOM Element which has the css transition</p> |
+| [propertyName] | <code>string</code> | <p>transition's propertyName. e.g. &quot;width&quot;</p> |
+
+**Example**  
+```
+  menu.classList.add("open");
+  await waitForTransitionEnd(menu, "transform");
+  input.classList.add("visible");
+  await waitForTransitionEnd(input, "opacity");
+  input.focus();
 ```
 <a name="debounce"></a>
 
@@ -766,9 +812,7 @@ window.addEventListener("resize", throttle(updateSlider, 100));
 ```
 <a name="getValue"></a>
 
-## ~~getValue(obj, path) ⇒ <code>\*</code>~~
-***Deprecated***
-
+## getValue(obj, path) ⇒ <code>\*</code>
 <p>returns nested value without throwing an error if the parent doesn't exist</p>
 
 **Kind**: global function  
@@ -803,8 +847,8 @@ getValue(obj, "a.f") === undefined;
 
 | Param | Type |
 | --- | --- |
-| arg1 | <code>T</code> | 
-| arg2 | <code>T</code> | 
+| arg1 | <code>\*</code> | 
+| arg2 | <code>\*</code> | 
 
 **Example**  
 ```js
@@ -829,18 +873,18 @@ isFilledObject("text") === false;
 ```
 <a name="naiveClone"></a>
 
-## naiveClone(arg) ⇒ <code>Nullable.&lt;T&gt;</code> \| <code>Array.&lt;T&gt;</code>
-<p>returns a deep link of the provided argument</p>
+## naiveClone(arg) ⇒ <code>T</code>
+<p>returns a deep clone of the provided argument. supports any primitive types, arrays, sets, maps, dates which can also be deeply nested in an object.</p>
 
 **Kind**: global function  
 
 | Param | Type |
 | --- | --- |
-| arg | <code>Nullable.&lt;T&gt;</code> \| <code>Array.&lt;T&gt;</code> | 
+| arg | <code>T</code> | 
 
 **Example**  
 ```js
-const state = naiveClone(initialState);
+const state = naiveClone({a: {b: 123, c: false}});
 ```
 <a name="toArray"></a>
 

--- a/packages/js-utils/src/object-helpers/lib/getValue.ts
+++ b/packages/js-utils/src/object-helpers/lib/getValue.ts
@@ -3,7 +3,6 @@
  * @param {Object} obj - object to be looked for value
  * @param {string} path - a string with dot separated levels: e.g "a.b"
  * @returns {*} - returned the found value or undefined
- * @deprecated - use typescript's optional chaining feature instead
  *
  * @example
  * const obj = {

--- a/packages/js-utils/src/object-helpers/lib/isEqual.ts
+++ b/packages/js-utils/src/object-helpers/lib/isEqual.ts
@@ -1,19 +1,80 @@
-import { toString } from './toString';
+function getExtendedType(arg: unknown) {
+  if (typeof arg !== "object") return typeof arg;
+  if (arg === null) return "null";
+  if (Array.isArray(arg)) return "array";
+  if (arg instanceof Set) return "set";
+  if (arg instanceof Map) return "map";
+  if (arg instanceof Date) return "date";
+  return "object";
+}
+
+function equalArrays(arg1: Array<unknown>, arg2: Array<unknown>) {
+  if (arg1.length !== arg2.length) return false;
+
+  return arg1.every((item, ix) => isEqual(item, arg2[ix]));
+}
+
+// currently the order of items matter in the comparison
+function equalSets(arg1: Set<unknown>, arg2: Set<unknown>) {
+  return equalArrays(Array.from(arg1), Array.from(arg2));
+}
+
+// currently the order of items matter in the comparison
+function equalMaps(arg1: Map<unknown, unknown>, arg2: Map<unknown, unknown>) {
+  return equalArrays(Array.from(arg1), Array.from(arg2));
+}
+
+function equalDates(arg1: Date, arg2: Date) {
+  return arg1.getTime() === arg2.getTime();
+}
+
+function equalRecords(arg1: Record<string|symbol, unknown>, arg2: Record<string|symbol, unknown>) {
+  return equalArrays(Object.entries(arg1), Object.entries(arg2));
+}
 
 /**
  * compare two arguments, for object their toString values are compared
- * @param {T} arg1
- * @param {T} arg2
+ * @param {*} arg1
+ * @param {*} arg2
  * @returns {boolean}
  * @example
  * if (!isEqual(oldState, newState)) console.log('state changed');
  */
-export const isEqual = <T>(arg1: T, arg2: T): boolean => {
-  if (typeof arg1 !== typeof arg2) {
+export const isEqual = (arg1: unknown, arg2: unknown): boolean => {
+  const arg1Type = getExtendedType(arg1);
+  const arg2Type = getExtendedType(arg2);
+
+  if (arg1Type !== arg2Type) {
     return false;
   }
-  if (typeof arg1 === 'object') {
-    return toString(arg1).localeCompare(toString(arg2)) === 0;
+
+  // primitives
+  if (typeof arg1 !== 'object') {
+    return arg1 === arg2;
   }
-  return arg1 === arg2;
+
+  // reference to the same object
+  if (arg1 === arg2) return true;
+
+  // one is null, and the other one wasn't obviously the same on the last step
+  if (arg1 === null || arg2 === null) return false;
+
+  if (arg1Type === "array") {
+    return equalArrays(arg1 as Array<unknown>, arg2 as Array<unknown>);
+  }
+
+  if (arg1Type === "set") {
+    return equalSets(arg1 as Set<unknown>, arg2 as Set<unknown>);
+  }
+
+  if (arg1Type === "map") {
+    return equalMaps(arg1 as Map<unknown, unknown>, arg2 as Map<unknown, unknown>);
+  }
+
+  if (arg1Type === "date") {
+    return equalDates(arg1 as Date, arg2 as Date);
+  }
+
+  // based on object literals
+  return equalRecords(arg1 as Record<string|symbol, unknown>, arg2 as Record<string|symbol, unknown>);
 };

--- a/packages/js-utils/src/object-helpers/lib/naiveClone.ts
+++ b/packages/js-utils/src/object-helpers/lib/naiveClone.ts
@@ -1,31 +1,26 @@
-import { Nullable } from "../../types/Nullable";
-
-export function naiveClone<T>(arg: Array<T>): Array<T>;
-
-export function naiveClone<T>(arg: T): T;
-
 /**
- * returns a deep link of the provided argument
- * @param {Nullable<T> | Array<T>} arg
- * @returns {Nullable<T> | Array<T>}
+ * returns a deep clone of the provided argument. supports any primitive types, arrays, sets, maps, dates which can also be deeply nested in an object.
+ * @param {T} arg
+ * @returns {T}
  * @example
- * const state = naiveClone(initialState);
+ * const state = naiveClone({a: {b: 123, c: false}});
  */
-export function naiveClone<T>(arg: Nullable<T> | Array<T>): Nullable<T> | Array<T> {
-  if (typeof arg !== 'object') {
+export function naiveClone<T>(arg: T): T {
+  if (typeof arg !== 'object' || arg === null) {
     return arg;
   }
-
-  if (arg === null) {
-    return null;
+  else if (Array.isArray(arg)) {
+    return arg.map(a => naiveClone(a)) as unknown as T;
+  }
+  else if (arg instanceof Set) {
+    return new Set(naiveClone(Array.from(arg))) as unknown as T;
+  }
+  else if (arg instanceof Map) {
+    return new Map(naiveClone(Array.from(arg))) as unknown as T;
+  }
+  else if (arg instanceof Date) {
+    return new Date(arg) as unknown as T;
   }
 
-  if (Array.isArray(arg)) {
-    return arg.map(a => naiveClone(a));
-  }
-
-  return Object.entries(arg).reduce((result, [key, value]) => {
-    result[key] = naiveClone(value);
-    return result;
-  }, {} as any);
+  return Object.fromEntries(Object.entries(arg).map(([k, v]) => [k, naiveClone(v)])) as unknown as T;
 };

--- a/packages/js-utils/src/object-helpers/tests/isEqual.test.ts
+++ b/packages/js-utils/src/object-helpers/tests/isEqual.test.ts
@@ -1,23 +1,95 @@
 import { isEqual } from '../lib/isEqual';
 
-const obj1 = {
-  isEqual: true,
-};
-const obj2 = {
-  isEqual: true,
-};
-const obj3 = {
-  isEqual: false,
-};
-const mystring = 'yolo';
-const mystring2 = 'yolo';
-const mystring3 = 'yohlo';
-const mystring4 = 'Yolo';
+test('compare Strings', () => {
+  const str1 = 'T-800';
+  const str2 = 'T-800';
+  const str3 = 'T-1000';
 
-test('should compare object arguments', () => {
+  expect(isEqual(str1, str2)).toBe(true);
+  expect(isEqual(str1, str3)).toBe(false);
+});
+
+test('compare Dates', () => {
+  const date1 = new Date('2029-08-10T20:45');
+  const date2 = new Date('2029-08-10T20:45');
+  const date3 = new Date('1984-05-13T01:52');
+
+  expect(isEqual(date1, date2)).toBe(true);
+  expect(isEqual(date1, date3)).toBe(false);
+});
+
+test('compare Arrays', () => {
+  const arr1 = [1, 2, 3];
+  const arr2 = [1, 2, 3];
+  const arr3 = [1, 2, '3'];
+  const arr4 = [1, 2, 3, 4];
+
+  expect(isEqual(arr1, arr2)).toBe(true);
+  expect(isEqual(arr1, arr3)).toBe(false);
+  expect(isEqual(arr1, arr4)).toBe(false);
+});
+
+test('compare Sets', () => {
+  const set1 = new Set([1, 2, 3]);
+  const set2 = new Set([1, 2, 3]);
+  const set3 = new Set([1, 2, '3']);
+  const set4 = new Set([1, 2, 3, 4]);
+
+  expect(isEqual(set1, set2)).toBe(true);
+  expect(isEqual(set1, set3)).toBe(false);
+  expect(isEqual(set1, set4)).toBe(false);
+});
+
+test('compare Maps', () => {
+  const map1 = new Map([
+    [1, 2],
+    [3, 4],
+  ]);
+  const map2 = new Map([
+    [1, 2],
+    [3, 4],
+  ]);
+  const map3 = new Map([
+    [1, 2],
+    [3, 4],
+    [5, 6],
+  ]);
+  const map4 = new Map([
+    [1, 2],
+    [5, 6],
+  ]);
+
+  expect(isEqual(map1, map2)).toBe(true);
+  expect(isEqual(map1, map3)).toBe(false);
+  expect(isEqual(map1, map4)).toBe(false);
+});
+
+test('compare Objects', () => {
+  const symbol = Symbol('symbol');
+  const obj1 = {
+    a: [1, 2, 'T-800', new Date('1984-05-13T01:52')],
+    b: {
+      c: new Map([[symbol, true]]),
+    },
+    [symbol]: 1234,
+  };
+
+  const obj2 = {
+    a: [1, 2, 'T-800', new Date('1984-05-13T01:52')],
+    b: {
+      c: new Map([[symbol, true]]),
+    },
+    [symbol]: 1234,
+  };
+
+  const obj3 = {
+    a: [1, 2, 'T-1000', new Date('1984-05-13T01:52')],
+    b: {
+      c: new Map([[symbol, true]]),
+    },
+    [symbol]: 1234,
+  };
+
   expect(isEqual(obj1, obj2)).toBe(true);
   expect(isEqual(obj1, obj3)).toBe(false);
-  expect(isEqual(mystring, mystring2)).toBe(true);
-  expect(isEqual(mystring2, mystring3)).toBe(false);
-  expect(isEqual(mystring, mystring4)).toBe(false);
 });

--- a/packages/js-utils/src/object-helpers/tests/naiveClone.test.ts
+++ b/packages/js-utils/src/object-helpers/tests/naiveClone.test.ts
@@ -25,3 +25,56 @@ describe('Clone an Object', () => {
     expect(typeof obj).toBe(typeof clone);
   });
 });
+
+describe('Clone Sets', () => {
+  const set = new Set<any>(['a', { c: true }]);
+  const origin = set;
+  const clone = naiveClone(origin);
+
+  test('clone should deep equal origin', () => {
+    expect(clone).toStrictEqual(origin);
+  });
+
+  test('clone should not be a reference to the same object as origin', () => {
+    expect(clone).not.toBe(origin);
+  });
+
+  test('clone nested items should not be a reference to the same object as in the origin', () => {
+    // comparing the {c: true} in both
+    expect([...clone.values()][1]).not.toBe([...origin.values()][1]);
+  });
+});
+
+describe('Clone Maps', () => {
+  const map = new Map<any, any>([
+    ['a', 1],
+    ['b', { c: true }],
+  ]);
+  const origin = { filed: map };
+  const clone = naiveClone(origin);
+
+  test('clone should deep equal origin', () => {
+    expect(clone).toStrictEqual(origin);
+  });
+
+  test('clone should not be a reference to the same object as origin', () => {
+    expect(clone).not.toBe(origin);
+  });
+
+  test('clone nested items should not be a reference to the same object as in the origin', () => {
+    expect(clone.filed.get('b')).not.toBe(origin.filed.get('b'));
+  });
+});
+
+describe('Clone Date', () => {
+  const origin = new Date();
+  const clone = naiveClone(origin);
+
+  test('clone should deep equal origin', () => {
+    expect(clone).toStrictEqual(origin);
+  });
+
+  test('clone should not be a reference to the same Date object as origin', () => {
+    expect(clone).not.toBe(origin);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     "module": "ESNext" /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
-      "es2015",
+      "es2020",
       "dom"
     ] /* Specify library files to be included in the compilation:  */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
support `Set`s, `Map`s and `Date`s in the `Component#state`,
remove deprecated tag from a not deprecated helper,
update tsconfig lib version to support `Object.entriesFrom`,
rebuild the docs

== Description ==

- It was previously not possible to use Dates, Sets and Maps in state. e.g `this.setState({start: new Date()})` would be replaced with `start: {}` when reading the `state`. This PR adds the support for those types
- There was a bug when a nested object was mutated after passing it to setState, then the reaction wasn't invoked when passing the modified object to `setState` :
```js
const obj = {k: true};
this.setState({obj});

obj.k = false;
this.setState({obj}); // ==> wouln'd trigger a `reaction`
```
---

The deep clone implementation could be replaced with simply using platform's `structuredClone`. But that wouldn't support functions and symbols in the object. I don't see any use case for functions in the components state. But `Symbol`s on the other hand might be used for example for enums.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
js-utils, (indirectly the future will be added to core/components state)