### PR TITLE
ci: remove node versions reached their end-of-life from CI matrix and replace with current versions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
== Description ==

PR https://github.com/kluntje/kluntje/pull/66 's CI test is failing due to missing ES2018 features on node 10.

I have updated the node versions to the current versions in Maintenance, LTS and latest.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
