### PR TITLE
refactor(services): provide better trace output, provide support for all console methods

### DIFF
--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -93,6 +93,16 @@ DebuggerService.error("Error");
 
 ```
 
+When using in Jest unit tests, make sure using `jest.mock` to properly mock the imported module.
+
+```javascript
+import { DebuggerService } from "@kluntje/services";
+jest.mock("@kluntje/services");
+
+// e.g.
+spyOn(DebuggerService, "error");
+```
+
 ### LazyConnectService
 
 Service to trigger callback, when component is in viewport.

--- a/packages/services/src/DebuggerService.ts
+++ b/packages/services/src/DebuggerService.ts
@@ -1,24 +1,15 @@
 import URLSearchParamsService from './URLSearchParamsService';
 
-class DebuggerService {
-  get debugModeActive() {
-    return URLSearchParamsService.get('js-debug') !== null;
-  }
-
-  log(message?: any, ...args: any[]) {
-    if (this.debugModeActive === false) return;
-    console.log(message, ...args);
-  }
-
-  warn(message?: any, ...args: any[]) {
-    if (this.debugModeActive === false) return;
-    console.warn(message, ...args);
-  }
-
-  error(message?: any, ...args: any[]) {
-    if (this.debugModeActive === false) return;
-    console.error(message, ...args);
-  }
+function debugModeActive() {
+  return URLSearchParamsService.get('js-debug') !== null;
 }
 
-export default new DebuggerService();
+const handler = {
+  get(target: Console, prop: keyof Console) {
+    if (debugModeActive()) return target[prop];
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    else return () => {};
+  },
+};
+
+export default new Proxy(console, handler);


### PR DESCRIPTION
== Description ==

This will change the link to the js location in the devtools Console when using log methods from DebuggerService.ts to where ever it was called.
Also other `console` methods can be used in addition to log, warn and error.


This can also be easily extended to support other use cases such as:

Log Level:
```js
import Logger, { LogLevel  } from "@kluntje/services/DebuggerService";

Logger.logLevel = LogLevel.WARN;
Logger.log(1); // nothing
Logger.warn(2); // logs
Logger.error(3); // logs
```

Custom Loggers:
```js
import Logger from "@kluntje/services/DebuggerService";

class Foo {
  
  logger = new Logger(() => /* some condition */);
  // this.logger.log() will only log when component has certain conditions

}
```


== Closes issue(s) ==


== Changes ==
@kluntje/services/DebuggerService

== Affected Packages ==
services