### PR TITLE
feat(core): add support for extending built-in elements to tag decorator

### DIFF
--- a/packages/core/src/decorators/tag.ts
+++ b/packages/core/src/decorators/tag.ts
@@ -11,9 +11,9 @@
  * ```
  * @returns {Function}
  */
-export default function tag(tagName: string): Function {
+export default function tag(tagName: string, options?: ElementDefinitionOptions): Function {
   return function <T extends { new (): HTMLElement }>(ComponentClass: T) {
-    customElements.define(tagName, ComponentClass);
+    customElements.define(tagName, ComponentClass, options);
 
     return ComponentClass;
   };


### PR DESCRIPTION
== Description ==
Usage example:
```js
import { tag } from "@kluntje/core";

@tag("my-form", { extends: "form" })
class MyForm extends HTMLFormElement {
  // ...
}
```

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
core