### PR TITLE
fix(js-utils::fetchjson): when fetching, reject when the server response was not successfull

### DIFF
--- a/packages/js-utils/src/api-helpers/lib/fetchJSON.ts
+++ b/packages/js-utils/src/api-helpers/lib/fetchJSON.ts
@@ -11,7 +11,18 @@
  * fetchJSON("https://some.api/path").then((data) => console.log("myData:", data));
  */
 export const fetchJSON = <T = any>(url: string, options?: RequestInit): Promise<T> => {
-  return fetch(url, options)
-          .then(response => (response.json() as Promise<T>));
+  return new Promise((resolve, reject) => {
+    fetch(url, options)
+          .then(response => {
+            // client/server error 4xx, 5xx
+            if (!response.ok) {
+              reject(response);
+              return;
+            }
+            resolve(response.json() as Promise<T>);
+          })
+          // (and) network error e.g. user is offline
+          .catch(err => reject(err));
+  });
 };
 


### PR DESCRIPTION
also return the response in case the error message, code, etc need to be used.
this prevnets for example a generic json parse error each time the request is not successful.

== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
js-utils