### PR TITLE
types(core): added component's state typing

### DIFF
--- a/packages/core/src/component.types.ts
+++ b/packages/core/src/component.types.ts
@@ -10,8 +10,6 @@ export interface ComponentEvent<T = any> {
   options?: AddEventListenerOptions;
 }
 
-export type ComponentStates = Record<string, any>;
-
 export type ComponentReactions<T = any> = Record<string, Array<Function | keyof T>>;
 
 export type ComponentProps<T> = Record<string, PropDefinition<T>>;


### PR DESCRIPTION
== Description ==
Adds typing support for the Component's state. It allows us to take advantage of TypeScript to detect errors easily (in the build phase). 

It's similar to how state is typed in React library:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/v17/index.d.ts

The changes are added in a backward-compatible way so that existing components would not break. It forces us to do some type assertions, sometimes resigning from TypeScript support.

Example use case:
```
type ExampleState = {
    data?: { text: string };
    pageNumber: number;
    pageSize: number;
};

export class DVComponent extends Component<ExampleState> {
    ...  
    setState({ data: "incorrect"});    // ❌ type check failure 
    setState({ pageNumber: 2 });     // ✅
    this.state.nonExisting;                // ❌ type check failure
    this.state.pageNumber;             // ✅ returns number   
    ...
}
```

== Changes ==
 Just typing the annotation in the core package. The resulting JavaScript should not be affected.

== Affected Packages ==
- core
