### PR TITLE
refactor(js-utils): removed log warning from removeEvent util

### DIFF
--- a/packages/js-utils/src/dom-helpers/lib/removeEvent.ts
+++ b/packages/js-utils/src/dom-helpers/lib/removeEvent.ts
@@ -23,7 +23,6 @@ export const removeEvent = <T extends Event = Event>(
   if (target === undefined
     || target === null
     || (isIterable(target) && !hasElements(target))) {
-    console.warn('no target found');
     return;
   }
 

--- a/packages/js-utils/src/dom-helpers/tests/removeEvent.test.ts
+++ b/packages/js-utils/src/dom-helpers/tests/removeEvent.test.ts
@@ -25,7 +25,6 @@ describe('removeEvent tests:', () => {
       document.createElement('button'),
     ];
     mockContext = new MockContext();
-    spyOn(console, 'warn');
     spyOn(mockTarget, 'removeEventListener').and.callThrough();
     spyOn(mockTargets[0], 'removeEventListener').and.callThrough();
     spyOn(mockTargets[1], 'removeEventListener').and.callThrough();
@@ -41,11 +40,6 @@ describe('removeEvent tests:', () => {
 
   describe('eventListener tests:', () => {
     describe('no target element', () => {
-      test('should should log warning', () => {
-        removeEvent(null, 'click', mockContext.mockHandler, mockContext);
-        expect(console.warn).toBeCalled();
-      });
-
       test('should not try to add eventListener', () => {
         removeEvent(null, 'click', mockContext.mockHandler, mockContext);
         expect(mockContext.mockHandler).not.toBeCalled();


### PR DESCRIPTION
== Description ==

Addition toPR https://github.com/kluntje/kluntje/pull/77
In above PR  the log was removed from "onEvent" method only, but I was not aware that it also existed on "removeEvent"

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
js-utils
