### PR TITLE
fix(core): props defaultValue could always ba an array reflect that to the TS type

### DIFF
--- a/packages/core/src/decorators/prop.ts
+++ b/packages/core/src/decorators/prop.ts
@@ -26,7 +26,7 @@ export type PropDefinition<T = any> = {
   /**
    * default value for the property, when the attribute is not present
    */
-  defaultValue?: string | boolean | number | Record<string, unknown> | undefined | null;
+  defaultValue?: string | boolean | number | Record<string, unknown> | Array<unknown> | undefined | null;
   /**
    * list of components methods, method name which should be called when the attribute/property is changed
    */


### PR DESCRIPTION


== Description ==
i.e. there is no difference between converting to an object or an array, it only does `JSON.parse()` but the TS type was missing

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
@kluntje/core