### PR TITLE
fix(core): add missing parentheses for the logic to work correctly

### DIFF
--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -202,6 +202,7 @@ export class Component extends HTMLElement {
    * Description
    */
   private async setupComponent(): Promise<void> {
+    this.initializeProps();
     if (this.asyncRenderingEnabled) {
       await this.renderAsync();
     } else {
@@ -220,7 +221,6 @@ export class Component extends HTMLElement {
     this.enableDecoratedProperties();
     this.generateUI();
     this.generateEvents();
-    this.initializeProps();
   }
 
   /**

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -429,9 +429,8 @@ export class Component extends HTMLElement {
       prop.defaultValue = prop.hasOwnProperty('defaultValue') ? prop.defaultValue : this[propName];
       //@ts-ignore - assuming user won't use any non supported type, in any case switch statement has a default type in the casting for that
       prop.type =
-        prop.type || (prop.defaultValue !== null && prop.defaultValue !== undefined)
-          ? typeof prop.defaultValue
-          : 'string';
+        prop.type ||
+        (prop.defaultValue !== null && prop.defaultValue !== undefined ? typeof prop.defaultValue : 'string');
     });
   }
 


### PR DESCRIPTION
== Description ==

 a pair of parentheses where missing in the if statement which had the result that when `type` was passed in the `@prop` but no `defaultValue` that the type was changed to `undefined`

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
Core